### PR TITLE
Build all branches, not just the live deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:experimental@sha256:787107d7f7953cb2d95ee81cc7332d79aca9328129318e08fc7ffbd252a20656
 FROM ocurrent/opam:debian-10-ocaml-4.08 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 COPY --chown=opam \
@@ -24,7 +23,7 @@ RUN opam pin add -yn current_ansi.dev "./ocurrent" && \
     opam pin add -yn current_web.dev "./ocurrent"
 COPY --chown=opam deployer.opam /src/
 RUN opam pin -yn add .
-RUN --mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000 opam install -y --deps-only .
+RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocurrent-deployer
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -1,0 +1,68 @@
+open Current.Syntax
+
+module Git = Current_git
+module Github = Current_github
+
+type org = string * Current_github.Api.t
+
+let org ~app ~account id =
+  let api =
+    Current_github.App.installation app ~account id
+    |> Current_github.Installation.api
+  in
+  account, api
+
+let head_of ~github repo name = Github.Api.head_of github repo (`Ref ("refs/heads/" ^ name))
+
+(* Strip deployment information and remove duplicates. *)
+let ignore_branch items =
+  items
+  |> List.map (function
+      | (d, _, `Docker _) -> d, `Docker
+      | (d, _, `Unikernel _) -> d, `Unikernel
+    )
+  |> List.sort_uniq compare
+
+let status_of_build ~url b =
+  let+ state = Current.state b in
+  match state with
+  | Ok _              -> Github.Api.Status.v ~url `Success ~description:"Passed"
+  | Error (`Active _) -> Github.Api.Status.v ~url `Pending
+  | Error (`Msg m)    -> Github.Api.Status.v ~url `Failure ~description:m
+
+let repo ~web_ui ~build ~deploy ~org:(org, github) ~name builds =
+  let repo_name = Printf.sprintf "%s/%s" org name in
+  let repo = { Github.Repo_id.owner = org; name } in
+  let root = Current.return ~label:repo_name () in      (* Group by repo in the diagram *)
+  Current.with_context root @@ fun () ->
+  let builds =
+    let refs = Github.Api.ci_refs github repo in
+    let collapse_value = repo_name ^ "-builds" in
+    let url = web_ui collapse_value in
+    let pipeline =
+      refs
+      |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
+      let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+      Current.all (
+        ignore_branch builds |> List.map (fun (dockerfile, target) -> build ~dockerfile ~src target)
+      )
+      |> status_of_build ~url
+      |> Github.Api.Commit.set_status commit "deployability"
+    in
+    Current.collapse
+      ~key:"repo" ~value:collapse_value
+      ~input:refs pipeline
+  and deployments =
+    Current.all (
+      builds |> List.map (fun (dockerfile, branch, target) ->
+          let commit = head_of ~github repo branch in
+          let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+          let collapse_value = Printf.sprintf "%s-%s-%s" repo_name dockerfile branch in
+          let build = deploy ~dockerfile ~src ~commit ~collapse_value target in
+          Current.collapse
+            ~key:"repo" ~value:collapse_value
+            ~input:commit build
+        )
+    )
+  in
+  Current.all [builds; deployments]

--- a/src/build.mli
+++ b/src/build.mli
@@ -1,0 +1,28 @@
+type org
+
+val org :
+  app:Current_github.App.t ->
+  account:string -> int -> org
+(** Look up a GitHub organisation by ID. *)
+
+val repo :
+  web_ui:(string -> Uri.t) ->
+  build:(dockerfile:string ->
+         src:Current_git.Commit.t Current.t ->
+         [`Docker | `Unikernel] ->
+         unit Current.t) ->
+  deploy:(dockerfile:string ->
+          src:Current_git.Commit.t Current.t ->
+          commit:Current_github.Api.Commit.t Current.t ->
+          collapse_value:string ->
+          ([`Docker of _ | `Unikernel of _ ] as 'a) -> unit Current.t) ->
+  org:org ->
+  name:string ->
+  (string * string * 'a) list ->
+  unit Current.t
+(** [repo ~web_ui ~build ~deploy ~org ~name builds] is an OCurrent pipeline to
+    handle all builds and deployments under [org/name].
+    @param build Sub-pipeline used to build and test every branch and PR.
+    @param deploy Sub-pipeline used to deploy each specified deployment branch.
+    @param builds A list of (dockerfile, live-branch, target) tuples
+                  (e.g. ["Dockerfile.web", "live-web", `Docker ...]). *)

--- a/src/main.ml
+++ b/src/main.ml
@@ -1,9 +1,7 @@
 (* This is the main entry-point for the executable.
    Edit [cmd] to set the text for "--help" and modify the command-line interface. *)
 
-let () =
-  Unix.putenv "DOCKER_BUILDKIT" "1";
-  Logging.init ()
+let () = Logging.init ()
 
 let webhooks = [
   "github", Current_github.input_webhook

--- a/src/main.ml
+++ b/src/main.ml
@@ -17,10 +17,8 @@ let read_channel_uri path =
     Fmt.failwith "Failed to read slack URI from %S: %a" path Fmt.exn ex
 
 let main config mode app slack =
-  let installation = Current_github.App.installation app ~account:"ocurrent" 6853813 in
-  let github = Current_github.Installation.api installation in
   let channel = read_channel_uri slack in
-  let engine = Current.Engine.create ~config (Pipeline.v ~github ~notify:channel) in
+  let engine = Current.Engine.create ~config (Pipeline.v ~app ~notify:channel) in
   Logging.run begin
     Lwt.choose [
       Current.Engine.thread engine;  (* The main thread evaluating the pipeline. *)

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -33,9 +33,11 @@ let notify ~channel ~service ~commit ~repo x =
   ]
 
 let docker ~dockerfile src =
-  let label = Printf.sprintf "build %s" dockerfile in
-  let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
-  Docker.build ~label ~dockerfile ~pull:true ~timeout (`Git src)
+  Docker.build (`Git src)
+    ~label:dockerfile
+    ~dockerfile:(Current.return (`File (Fpath.v dockerfile)))
+    ~pull:true
+    ~timeout
 
 (* Build [commit] and deploy as unikernel [service]. *)
 let mirage ~dockerfile src =

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -13,12 +13,11 @@ let mirage_config = Mirage_m1_a.config ~ssh_host:mirage_host_ssh ()
 
 let timeout = Duration.of_min 50    (* Max build time *)
 
-let ocaml_ci = { Github.Repo_id.owner = "ocurrent"; name = "ocaml-ci" }
-let deployer = { Github.Repo_id.owner = "ocurrent"; name = "ocurrent-deployer" }
-let base_images = { Github.Repo_id.owner = "ocurrent"; name = "docker-base-images " }
-let mirage_www = { Github.Repo_id.owner = "mirage"; name = "mirage-www" }
+let web_ui =
+  let base = Uri.of_string "https://deploy.ocamllabs.io/" in
+  fun repo -> Uri.with_query' base ["repo", repo]
 
-let notify ~channel ~service ~commit x =
+let notify ~channel ~service ~commit ~repo x =
   let s =
     let+ state = Current.state x
     and+ commit = commit in
@@ -26,43 +25,127 @@ let notify ~channel ~service ~commit x =
     Fmt.strf "@[<h>Deploy <%a|%a> as %s: <%s|%a>@]"
       Uri.pp uri Github.Api.Commit.pp commit
       service
-      "https://deploy.ocamllabs.io" (Current_term.Output.pp Current.Unit.pp) state
+      (Uri.to_string (web_ui repo)) (Current_term.Output.pp Current.Unit.pp) state
   in
   Current.all [
     Current_slack.post channel ~key:("deploy-" ^ service) s;
     x   (* If [x] fails, the whole pipeline should fail too. *)
   ]
 
-(* Build [commit], tag as [tag], and update [service] to it. *)
-let deploy ~notify:channel ?(dockerfile="Dockerfile") ~tag ~service commit =
-  let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+let docker ~dockerfile src =
+  let label = Printf.sprintf "build %s" dockerfile in
   let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
-  let image = Docker.build ~dockerfile ~pull:true ~timeout (`Git src) in
-  Current.all [
-    Docker.tag ~tag image;
-    Docker.service ~name:service ~image ()
-  ]
-  |> notify ~channel ~service ~commit
+  Docker.build ~label ~dockerfile ~pull:true ~timeout (`Git src)
 
 (* Build [commit] and deploy as unikernel [service]. *)
-let mirage ~notify:channel ?(dockerfile="Dockerfile") ~service commit =
+let mirage ~dockerfile src =
   let module Docker = M1_a in
-  let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
   let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
-  let image = Docker.build ~build_args:["--build-arg"; "TARGET=hvt"] ~dockerfile ~pull:true ~timeout (`Git src) in
-  Mirage_m1_a.deploy mirage_config ~name:service image
-  |> notify ~channel ~service ~commit
+  Docker.build ~build_args:["--build-arg"; "TARGET=hvt"] ~dockerfile ~pull:true ~timeout (`Git src)
 
-let v ~github ~notify () =
-  let branch repo name = Github.Api.head_of github repo (`Ref ("refs/heads/" ^ name)) in
-  let deploy = deploy ~notify in
-  let mirage = mirage ~notify in
-  Current.all [
-    deploy (branch ocaml_ci "live-engine") ~dockerfile:"Dockerfile"     ~tag:"ocaml-ci-service:latest" ~service:"ocaml-ci_ci";
-    deploy (branch ocaml_ci "live-www")    ~dockerfile:"Dockerfile.web" ~tag:"ocaml-ci-web:latest" ~service:"ocaml-ci_web";
-    deploy (branch ocaml_ci "staging-www") ~dockerfile:"Dockerfile.web" ~tag:"ocaml-ci-web:staging" ~service:"test-www";
-    deploy (branch deployer "live")        ~dockerfile:"Dockerfile"     ~tag:"ci.ocamllabs.io-deployer:latest" ~service:"infra_deployer";
-    deploy (branch base_images "live")     ~dockerfile:"Dockerfile"     ~tag:"base-images:latest" ~service:"base-images_builder";
-    (* Unikernels: *)
-    mirage (branch mirage_www "live")    ~service:"mirage-www";
+type docker_deployment = {
+  service : string;
+  tag : string;
+}
+
+let head_of ~github repo name = Github.Api.head_of github repo (`Ref ("refs/heads/" ^ name))
+
+let repo_of_string s =
+  match String.split_on_char '/' s with
+  | [ owner; name ] -> { Github.Repo_id.owner; name }
+  | _ -> Fmt.failwith "Invalid repo name %S (should be 'owner/name')" s
+
+let ignore_branch items =
+  items
+  |> List.map (function
+      | (d, _, `Docker _) -> d, `Docker
+      | (d, _, `Unikernel _) -> d, `Unikernel
+    )
+  |> List.sort_uniq compare
+
+let status_of_build ~repo b =
+  let url = web_ui repo in
+  let+ state = Current.state b in
+  match state with
+  | Ok _              -> Github.Api.Status.v ~url `Success ~description:"Passed"
+  | Error (`Active _) -> Github.Api.Status.v ~url `Pending
+  | Error (`Msg m)    -> Github.Api.Status.v ~url `Failure ~description:m
+
+let repo ~github ~channel (repo_name, builds) =
+  let root = Current.return ~label:repo_name () in
+  Current.with_context root @@ fun () ->
+  let repo = repo_of_string repo_name in
+  let builds =
+    let refs = Github.Api.ci_refs github repo in
+    let collapse_value = repo_name ^ "-builds" in
+    let pipeline =
+      refs
+      |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
+      let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+      Current.all (
+        ignore_branch builds |> List.map (fun (dockerfile, target) ->
+            match target with
+            | `Docker -> Current.ignore_value (docker src ~dockerfile)
+            | `Unikernel -> Current.ignore_value (mirage src ~dockerfile)
+          )
+      )
+      |> status_of_build ~repo:collapse_value
+      |> Github.Api.Commit.set_status commit "deployability"
+    in
+    Current.collapse
+      ~key:"repo" ~value:collapse_value
+      ~input:refs pipeline
+  and deployments =
+    Current.all (
+      builds |> List.map (fun (dockerfile, branch, target) ->
+          let commit = head_of ~github repo branch in
+          let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+          let collapse_value = Printf.sprintf "%s-%s-%s" repo_name dockerfile branch in
+          let build =
+            match target with
+            | `Docker { service; tag } ->
+              let image = docker src ~dockerfile in
+              Current.all [
+                Docker.tag ~tag image;
+                Docker.service ~name:service ~image ()
+              ]
+              |> notify ~channel ~service ~commit ~repo:collapse_value
+            | `Unikernel service ->
+              mirage src ~dockerfile
+              |> Mirage_m1_a.deploy mirage_config ~name:service
+              |> notify ~channel ~service ~commit ~repo:collapse_value
+          in
+          Current.collapse
+            ~key:"repo" ~value:collapse_value
+            ~input:commit build
+        )
+    )
+  in
+  Current.all [builds; deployments]
+
+let docker ~service ~tag = `Docker { service; tag }
+let unikernel ~service = `Unikernel service
+
+(* This is a list of GitHub repositories to monitor.
+   For each one, it lists the Dockerfiles in it from which binaries can be built.
+   For each binary, it says which branch gives the desired live version of the service,
+   and where to deloy it. *)
+let v ~github ~notify:channel () =
+  Current.all @@ List.map (repo ~github ~channel) [
+    (* Docker services *)
+    "ocurrent/ocaml-ci", [
+      "Dockerfile",     "live-engine", docker ~tag:"ocaml-ci-service:latest" ~service:"ocaml-ci_ci";
+      "Dockerfile.web", "live-www",    docker ~tag:"ocaml-ci-web:latest"     ~service:"ocaml-ci_web";
+      "Dockerfile.web", "staging-www", docker ~tag:"ocaml-ci-web:staging"    ~service:"test-www";
+    ];
+    "ocurrent/ocurrent-deployer", [
+      "Dockerfile", "live", docker ~tag:"ci.ocamllabs.io-deployer:latest" ~service:"infra_deployer";
+    ];
+    "ocurrent/docker-base-images", [
+      "Dockerfile", "live", docker ~tag:"base-images:latest" ~service:"base-images_builder";
+    ];
+    (* Unikernels *)
+    "mirage/mirage-www", [
+      "Dockerfile", "live", unikernel ~service:"mirage-www";
+    ];
   ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -1,22 +1,69 @@
 open Current.Syntax
 
-let mirage_host_context = "m1-a"
-let mirage_host_ssh = "root@147.75.33.203"
-
-module Docker = Current_docker.Default
-module M1_a = Current_docker.Make(struct let docker_context = Some mirage_host_context end)
-module Git = Current_git
 module Github = Current_github
-module Mirage_m1_a = Mirage.Make(M1_a)
-
-let mirage_config = Mirage_m1_a.config ~ssh_host:mirage_host_ssh ()
 
 let timeout = Duration.of_min 50    (* Max build time *)
 
+module Toxis_service = struct
+  (* Docker services running on toxis. *)
+
+  type t = {
+    service : string;
+    tag : string;
+  }
+
+  module Docker = Current_docker.Default
+
+  (* Build [src/dockerfile] as a Docker service. *)
+  let build ~dockerfile src =
+    Docker.build (`Git src)
+      ~label:dockerfile
+      ~dockerfile:(Current.return (`File (Fpath.v dockerfile)))
+      ~pull:true
+      ~timeout
+
+  (* Update Docker service [service] to [image].
+     We also tag it, so that if someone redeploys the stack.yml then it will
+     still use this version. *)
+  let deploy ~tag ~service image =
+    Current.all [
+      Docker.tag ~tag image;
+      Docker.service ~name:service ~image ()
+    ]
+end
+
+module Packet_unikernel = struct
+  (* Mirage unikernels running on packet.net *)
+
+  let mirage_host_context = "m1-a"
+  let mirage_host_ssh = "root@147.75.33.203"
+
+  module Docker = Current_docker.Make(struct let docker_context = Some mirage_host_context end)
+  module Mirage_m1_a = Mirage.Make(Docker)
+
+  let config = Mirage_m1_a.config ~ssh_host:mirage_host_ssh ()
+
+  (* Build [src/dockerfile] as an HVT unikernel. *)
+  let build ~dockerfile src =
+    let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
+    Docker.build (`Git src)
+      ~build_args:["--build-arg"; "TARGET=hvt"]
+      ~dockerfile
+      ~pull:true
+      ~timeout
+
+  let deploy service =
+    Mirage_m1_a.deploy config ~name:service
+end
+
+(* [web_ui collapse_value] is a URL back to the deployment service, for links
+   in status messages. *)
 let web_ui =
   let base = Uri.of_string "https://deploy.ocamllabs.io/" in
   fun repo -> Uri.with_query' base ["repo", repo]
 
+(* Push a Slack notification to [channel] to say that [x] is updating [service] to [commit].
+   [repo] is used for the URL in the message. *)
 let notify ~channel ~service ~commit ~repo x =
   let s =
     let+ state = Current.state x
@@ -32,136 +79,52 @@ let notify ~channel ~service ~commit ~repo x =
     x   (* If [x] fails, the whole pipeline should fail too. *)
   ]
 
-let docker ~dockerfile src =
-  Docker.build (`Git src)
-    ~label:dockerfile
-    ~dockerfile:(Current.return (`File (Fpath.v dockerfile)))
-    ~pull:true
-    ~timeout
+(* Build [src/dockerfile]. *)
+let build ~dockerfile ~src = function
+  | `Docker -> Current.ignore_value (Toxis_service.build src ~dockerfile)
+  | `Unikernel -> Current.ignore_value (Packet_unikernel.build src ~dockerfile)
 
-(* Build [commit] and deploy as unikernel [service]. *)
-let mirage ~dockerfile src =
-  let module Docker = M1_a in
-  let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
-  Docker.build ~build_args:["--build-arg"; "TARGET=hvt"] ~dockerfile ~pull:true ~timeout (`Git src)
+(* Build and deploy [src/dockerfile]. *)
+let deploy ~channel ~dockerfile ~src ~commit ~collapse_value = function
+  | `Docker { Toxis_service.service; tag } ->
+    Toxis_service.build src ~dockerfile
+    |> Toxis_service.deploy ~service ~tag
+    |> notify ~channel ~service ~commit ~repo:collapse_value
+  | `Unikernel service ->
+    Packet_unikernel.build src ~dockerfile
+    |> Packet_unikernel.deploy service
+    |> notify ~channel ~service ~commit ~repo:collapse_value
 
-type docker_deployment = {
-  service : string;
-  tag : string;
-}
-
-let head_of ~github repo name = Github.Api.head_of github repo (`Ref ("refs/heads/" ^ name))
-
-let repo_of_string s =
-  match String.split_on_char '/' s with
-  | [ owner; name ] -> { Github.Repo_id.owner; name }
-  | _ -> Fmt.failwith "Invalid repo name %S (should be 'owner/name')" s
-
-let ignore_branch items =
-  items
-  |> List.map (function
-      | (d, _, `Docker _) -> d, `Docker
-      | (d, _, `Unikernel _) -> d, `Unikernel
-    )
-  |> List.sort_uniq compare
-
-let status_of_build ~repo b =
-  let url = web_ui repo in
-  let+ state = Current.state b in
-  match state with
-  | Ok _              -> Github.Api.Status.v ~url `Success ~description:"Passed"
-  | Error (`Active _) -> Github.Api.Status.v ~url `Pending
-  | Error (`Msg m)    -> Github.Api.Status.v ~url `Failure ~description:m
-
-let repo ~github ~channel (repo_name, builds) =
-  let root = Current.return ~label:repo_name () in
-  Current.with_context root @@ fun () ->
-  let repo = repo_of_string repo_name in
-  let builds =
-    let refs = Github.Api.ci_refs github repo in
-    let collapse_value = repo_name ^ "-builds" in
-    let pipeline =
-      refs
-      |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
-      let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
-      Current.all (
-        ignore_branch builds |> List.map (fun (dockerfile, target) ->
-            match target with
-            | `Docker -> Current.ignore_value (docker src ~dockerfile)
-            | `Unikernel -> Current.ignore_value (mirage src ~dockerfile)
-          )
-      )
-      |> status_of_build ~repo:collapse_value
-      |> Github.Api.Commit.set_status commit "deployability"
-    in
-    Current.collapse
-      ~key:"repo" ~value:collapse_value
-      ~input:refs pipeline
-  and deployments =
-    Current.all (
-      builds |> List.map (fun (dockerfile, branch, target) ->
-          let commit = head_of ~github repo branch in
-          let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
-          let collapse_value = Printf.sprintf "%s-%s-%s" repo_name dockerfile branch in
-          let build =
-            match target with
-            | `Docker { service; tag } ->
-              let image = docker src ~dockerfile in
-              Current.all [
-                Docker.tag ~tag image;
-                Docker.service ~name:service ~image ()
-              ]
-              |> notify ~channel ~service ~commit ~repo:collapse_value
-            | `Unikernel service ->
-              mirage src ~dockerfile
-              |> Mirage_m1_a.deploy mirage_config ~name:service
-              |> notify ~channel ~service ~commit ~repo:collapse_value
-          in
-          Current.collapse
-            ~key:"repo" ~value:collapse_value
-            ~input:commit build
-        )
-    )
-  in
-  Current.all [builds; deployments]
-
-let docker ~service ~tag = `Docker { service; tag }
+let docker ~service ~tag = `Docker { Toxis_service.service; tag }
 let unikernel ~service = `Unikernel service
 
-let api ~app ~account id =
-  Current_github.App.installation app ~account id
-  |> Current_github.Installation.api
-
-let ocurrent_services ~github ~channel () =
-  Current.all @@ List.map (repo ~github ~channel) [
-    "ocurrent/ocaml-ci", [
+(* This is a list of GitHub repositories to monitor.
+   For each one, it lists the deployments that are made from that repository.
+   For each deployment, it says which Dockerfile to build, which branch gives
+   the desired live version of the service, and where to deloy it.
+   For each specified branch, we will call [deploy] on that branch to build and deploy it.
+   For all branches and PRs, we will call [build] to test that it could be deployed. *)
+let v ~app ~notify:channel () =
+  let ocurrent = Build.org ~app ~account:"ocurrent" 6853813 in
+  let mirage = Build.org ~app ~account:"mirage" 7175142 in
+  let repo (org, name, builds) =
+    Build.repo ~web_ui ~deploy:(deploy ~channel) ~build ~org ~name builds
+  in
+  Current.all @@ List.map repo [
+    (* OCurrent repositories *)
+    ocurrent, "ocaml-ci", [
       "Dockerfile",     "live-engine", docker ~tag:"ocaml-ci-service:latest" ~service:"ocaml-ci_ci";
       "Dockerfile.web", "live-www",    docker ~tag:"ocaml-ci-web:latest"     ~service:"ocaml-ci_web";
       "Dockerfile.web", "staging-www", docker ~tag:"ocaml-ci-web:staging"    ~service:"test-www";
     ];
-    "ocurrent/ocurrent-deployer", [
+    ocurrent, "ocurrent-deployer", [
       "Dockerfile", "live", docker ~tag:"ci.ocamllabs.io-deployer:latest" ~service:"infra_deployer";
     ];
-    "ocurrent/docker-base-images", [
+    ocurrent, "docker-base-images", [
       "Dockerfile", "live", docker ~tag:"base-images:latest" ~service:"base-images_builder";
     ];
-  ]
-
-let mirage_services ~github ~channel () =
-  Current.all @@ List.map (repo ~github ~channel) [
-    "mirage/mirage-www", [
+    (* Mirage repositories *)
+    mirage, "mirage-www", [
       "Dockerfile", "live", unikernel ~service:"mirage-www";
     ];
-  ]
-
-(* This is a list of GitHub repositories to monitor.
-   For each one, it lists the Dockerfiles in it from which binaries can be built.
-   For each binary, it says which branch gives the desired live version of the service,
-   and where to deloy it. *)
-let v ~app ~notify:channel () =
-  let ocurrent = api ~app ~account:"ocurrent" 6853813 in
-  let mirage = api ~app ~account:"mirage" 7175142 in
-  Current.all [
-    ocurrent_services ~github:ocurrent ~channel ();
-    mirage_services ~github:mirage ~channel ();
   ]

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -1,2 +1,2 @@
-val v : github:Current_github.Api.t -> notify:Current_slack.channel -> unit -> unit Current.t
-(** [v ~github ~notify ()] is a pipeline that keeps the services up-to-date. *)
+val v : app:Current_github.App.t -> notify:Current_slack.channel -> unit -> unit Current.t
+(** [v ~app ~notify ()] is a pipeline that keeps the services up-to-date. *)


### PR DESCRIPTION
This allows us to check that each PR is still deployable.

Note: this also disables the use of BuildKit, which is not safe now that we are testing PRs too (because it allows poisoning of the download cache).