### PR TITLE
Build unikernels locally

### DIFF
--- a/deployer.opam
+++ b/deployer.opam
@@ -8,6 +8,7 @@ depends: [
   "current_git"
   "current_github"
   "current_docker"
+  "current_slack"
   "fmt"
   "lwt"
   "cmdliner"

--- a/src/dune
+++ b/src/dune
@@ -14,4 +14,5 @@
    logs.fmt
    str
    lwt
-   lwt.unix))
+   lwt.unix)
+ (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/src/mirage.ml
+++ b/src/mirage.ml
@@ -1,15 +1,35 @@
 open Lwt.Infix
 open Current.Syntax
 
+module Raw = Current_docker.Raw
+
+let with_tmp ~prefix ~suffix fn =
+    let tmp_path = Filename.temp_file prefix suffix in
+    Lwt.finalize
+      (fun () -> fn tmp_path)
+      (fun () ->
+         Unix.unlink tmp_path;
+         Lwt.return_unit
+      )
+
+let ( >>!= ) = Lwt_result.bind
+
 module Op = struct
-  type t = {
-    ssh_host : string;
-  }
+  type t = No_context
 
   let id = "mirage-deploy"
 
-  module Key = Current.String
-  module Value = Current.String
+  module Key = struct
+    type t = {
+      name : string;
+      ssh_host : string;
+      docker_context : string option;
+    } [@@deriving to_yojson]
+
+    let digest t = Yojson.Safe.to_string (to_yojson t)
+  end
+
+  module Value = Raw.Image
   module Outcome = Current.Unit
 
   let re_valid_name = Str.regexp "^[A-Za-z][-0-9A-Za-z_]*$"
@@ -18,18 +38,34 @@ module Op = struct
     if not (Str.string_match re_valid_name name 0) then
       Fmt.failwith "Invalid unikernel name %S" name
 
-  let ssh t cmd =
-    let cmd = "ssh" :: t.ssh_host :: cmd in
+  let redeploy ~ssh_host name =
+    let cmd = ["ssh"; ssh_host; "mirage-redeploy"; name] in
     ("", Array.of_list cmd)
 
-  let publish t job name image =
+  let run image = Raw.Cmd.docker ["container"; "run"; "-d"; Raw.Image.hash image]
+  let docker_cp src dst = Raw.Cmd.docker ["cp"; src; dst]
+
+  let rsync src dst =
+    let cmd = [| "rsync"; "-vi"; src; dst |] in
+    ("", cmd)
+
+  let publish No_context job { Key.name; ssh_host; docker_context } image =
     Current.Job.log job "Deploy %a -> %s" Value.pp image name;
     validate_name name;
     Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
-    let cmd = ["/usr/local/bin/deploy-mirage"; name; image] in
-    Current.Process.exec ~cancellable:true ~job (ssh t cmd)
+    (* Extract unikernel image from Docker image: *)
+    with_tmp ~prefix:"ocurrent-deployer-" ~suffix:".hvt" @@ fun tmp_path ->
+    Raw.Cmd.with_container ~docker_context ~job ~kill_on_cancel:true (run image ~docker_context) (fun id ->
+        let src = Printf.sprintf "%s:/unikernel.hvt" id in
+        Current.Process.exec ~cancellable:true ~job (docker_cp ~docker_context src tmp_path)
+      ) >>!= fun () ->
+    (* rsync to remote host: *)
+    let remote_path = Printf.sprintf "%s:/srv/unikernels/%s.hvt" ssh_host name in
+    Current.Process.exec ~cancellable:true ~job (rsync tmp_path remote_path) >>!= fun () ->
+    (* Restart remote service: *)
+    Current.Process.exec ~cancellable:true ~job (redeploy ~ssh_host name)
 
-  let pp f (key, _v) = Fmt.pf f "@[<v2>deploy %a@]" Key.pp key
+  let pp f (key, _v) = Fmt.pf f "@[<v2>deploy %s@]" key.Key.name
 
   let auto_cancel = true
 end
@@ -37,13 +73,9 @@ end
 module Deploy = Current_cache.Output(Op)
 
 module Make(Docker : Current_docker.S.DOCKER) = struct
-  type t = Op.t
-
-  let config ~ssh_host () =
-    { Op.ssh_host }
-
-  let deploy t ~name image =
+  let deploy ~name ~ssh_host image =
     Current.component "deploy %s" name |>
     let> image = image in
-    Deploy.set t name (Docker.Image.hash image)
+    let docker_context = Docker.docker_context in
+    Deploy.set Op.No_context { Op.Key.name; ssh_host; docker_context } (Docker.Image.hash image |> Raw.Image.of_hash)
 end

--- a/src/mirage.mli
+++ b/src/mirage.mli
@@ -1,10 +1,4 @@
 module Make(Docker : Current_docker.S.DOCKER) : sig
-  type t
-
-  val config : ssh_host:string -> unit -> t
-  (** [config ~ssh_host ()] is a configuration which deploys to
-      [ssh_host], which must be the same host as [Docker]. *)
-
-  val deploy : t -> name:string -> Docker.Image.t Current.t -> unit Current.t
-  (** [deploy t ~name image] deploys [image] as the unikernel [name]. *)
+  val deploy : name:string -> ssh_host:string -> Docker.Image.t Current.t -> unit Current.t
+  (** [deploy ~name ~ssh_host image] deploys [image] as the unikernel [name] on [ssh_host]. *)
 end

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -35,13 +35,10 @@ end
 module Packet_unikernel = struct
   (* Mirage unikernels running on packet.net *)
 
-  let mirage_host_context = "m1-a"
   let mirage_host_ssh = "root@147.75.33.203"
 
-  module Docker = Current_docker.Make(struct let docker_context = Some mirage_host_context end)
+  module Docker = Current_docker.Default
   module Mirage_m1_a = Mirage.Make(Docker)
-
-  let config = Mirage_m1_a.config ~ssh_host:mirage_host_ssh ()
 
   (* Build [src/dockerfile] as an HVT unikernel. *)
   let build ~dockerfile src =
@@ -53,7 +50,7 @@ module Packet_unikernel = struct
       ~timeout
 
   let deploy service =
-    Mirage_m1_a.deploy config ~name:service
+    Mirage_m1_a.deploy ~name:service ~ssh_host:mirage_host_ssh
 end
 
 (* [web_ui collapse_value] is a URL back to the deployment service, for links


### PR DESCRIPTION
Build unikernels on the deployment host and then rsync to the target. This is to support targets that don't run Docker.