### PR TITLE
Deploy mirage-www from master branch

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -123,6 +123,6 @@ let v ~app ~notify:channel () =
     ];
     (* Mirage repositories *)
     mirage, "mirage-www", [
-      "Dockerfile", "live", unikernel ~service:"www" ["TARGET=hvt"; "EXTRA_FLAGS=--tls=true"];
+      "Dockerfile", "master", unikernel ~service:"www" ["TARGET=hvt"; "EXTRA_FLAGS=--tls=true"];
     ];
   ]


### PR DESCRIPTION
Now that the deployment seems to be working, it's probably easiest to deploy from the master branch.

/cc @hannesm