### PR TITLE
Refactor deployer

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -14,55 +14,72 @@ let org ~app ~account id =
 
 let head_of ~github repo name = Github.Api.head_of github repo (`Ref ("refs/heads/" ^ name))
 
-(* Strip deployment information and remove duplicates. *)
-let ignore_branch items =
-  items
-  |> List.map (function
-      | (d, _, `Docker _) -> d, `Docker
-      | (d, _, `Unikernel (_, flags)) -> d, `Unikernel flags
-    )
-  |> List.sort_uniq compare
-
-let status_of_build ~url b =
-  let+ state = Current.state b in
-  match state with
-  | Ok _              -> Github.Api.Status.v ~url `Success ~description:"Passed"
-  | Error (`Active _) -> Github.Api.Status.v ~url `Pending
-  | Error (`Msg m)    -> Github.Api.Status.v ~url `Failure ~description:m
-
-let repo ~web_ui ~build ~deploy ~org:(org, github) ~name builds =
-  let repo_name = Printf.sprintf "%s/%s" org name in
-  let repo = { Github.Repo_id.owner = org; name } in
-  let root = Current.return ~label:repo_name () in      (* Group by repo in the diagram *)
-  Current.with_context root @@ fun () ->
-  let builds =
-    let refs = Github.Api.ci_refs github repo in
-    let collapse_value = repo_name ^ "-builds" in
-    let url = web_ui collapse_value in
-    let pipeline =
-      refs
-      |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
-      let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
-      Current.all (
-        ignore_branch builds |> List.map (fun (dockerfile, target) -> build ~dockerfile ~src target)
-      )
-      |> status_of_build ~url
-      |> Github.Api.Commit.set_status commit "deployability"
-    in
-    Current.collapse
-      ~key:"repo" ~value:collapse_value
-      ~input:refs pipeline
-  and deployments =
-    Current.all (
-      builds |> List.map (fun (dockerfile, branch, target) ->
-          let commit = head_of ~github repo branch in
-          let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
-          let collapse_value = Printf.sprintf "%s-%s-%s" repo_name dockerfile branch in
-          let build = deploy ~dockerfile ~src ~commit ~collapse_value target in
-          Current.collapse
-            ~key:"repo" ~value:collapse_value
-            ~input:commit build
-        )
-    )
+(* Push a Slack notification to [channel] to say that [x] is updating [service] to [commit].
+   [repo] is used for the URL in the message. *)
+let notify ~channel ~web_ui ~service ~commit ~repo x =
+  let s =
+    let+ state = Current.state x
+    and+ commit = commit in
+    let uri = Github.Api.Commit.uri commit in
+    Fmt.strf "@[<h>Deploy <%a|%a> as %s: <%s|%a>@]"
+      Uri.pp uri Github.Api.Commit.pp commit
+      service
+      (Uri.to_string (web_ui repo)) (Current_term.Output.pp Current.Unit.pp) state
   in
-  Current.all [builds; deployments]
+  Current.all [
+    Current_slack.post channel ~key:("deploy-" ^ service) s;
+    x   (* If [x] fails, the whole pipeline should fail too. *)
+  ]
+
+module Make(T : S.T) = struct
+  let status_of_build ~url b =
+    let+ state = Current.state b in
+    match state with
+    | Ok _              -> Github.Api.Status.v ~url `Success ~description:"Passed"
+    | Error (`Active _) -> Github.Api.Status.v ~url `Pending
+    | Error (`Msg m)    -> Github.Api.Status.v ~url `Failure ~description:m
+
+  let repo ~channel ~web_ui ~org:(org, github) ~name build_specs =
+    let repo_name = Printf.sprintf "%s/%s" org name in
+    let repo = { Github.Repo_id.owner = org; name } in
+    let root = Current.return ~label:repo_name () in      (* Group by repo in the diagram *)
+    Current.with_context root @@ fun () ->
+    let builds =
+      let refs = Github.Api.ci_refs github repo in
+      let collapse_value = repo_name ^ "-builds" in
+      let url = web_ui collapse_value in
+      let pipeline =
+        refs
+        |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
+        let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+        Current.all (
+          build_specs |> List.map (fun (build_info, _deploys) -> T.build build_info src |> Current.ignore_value)
+        )
+        |> status_of_build ~url
+        |> Github.Api.Commit.set_status commit "deployability"
+      in
+      Current.collapse
+        ~key:"repo" ~value:collapse_value
+        ~input:refs pipeline
+    and deployments =
+      Current.all (
+        build_specs |> List.map (fun (build_info, deploys) ->
+            Current.all (
+              deploys |> List.map (fun (branch, deploy_info) ->
+                  let service = T.name deploy_info in
+                  let collapse_value = Printf.sprintf "%s-%s-%s" repo_name service branch in
+                  let commit = head_of ~github repo branch in
+                  let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
+                  let binary = T.build build_info src in
+                  T.deploy deploy_info binary
+                  |> notify ~channel ~web_ui ~service ~commit ~repo:collapse_value
+                  |> Current.collapse
+                    ~key:"repo" ~value:collapse_value
+                    ~input:commit
+                )
+            )
+          )
+      )
+    in
+    Current.all [builds; deployments]
+end

--- a/src/build.mli
+++ b/src/build.mli
@@ -5,24 +5,17 @@ val org :
   account:string -> int -> org
 (** Look up a GitHub organisation by ID. *)
 
-val repo :
-  web_ui:(string -> Uri.t) ->
-  build:(dockerfile:string ->
-         src:Current_git.Commit.t Current.t ->
-         [`Docker | `Unikernel of string list] ->
-         unit Current.t) ->
-  deploy:(dockerfile:string ->
-          src:Current_git.Commit.t Current.t ->
-          commit:Current_github.Api.Commit.t Current.t ->
-          collapse_value:string ->
-          ([`Docker of _ | `Unikernel of (_ * string list)] as 'a) -> unit Current.t) ->
-  org:org ->
-  name:string ->
-  (string * string * 'a) list ->
-  unit Current.t
-(** [repo ~web_ui ~build ~deploy ~org ~name builds] is an OCurrent pipeline to
-    handle all builds and deployments under [org/name].
-    @param build Sub-pipeline used to build and test every branch and PR.
-    @param deploy Sub-pipeline used to deploy each specified deployment branch.
-    @param builds A list of (dockerfile, live-branch, target) tuples
-                  (e.g. ["Dockerfile.web", "live-web", `Docker ...]). *)
+module Make(T : S.T) : sig
+  val repo :
+    channel:Current_slack.channel ->
+    web_ui:(string -> Uri.t) ->
+    org:org ->
+    name:string ->
+    (T.build_info * (string * T.deploy_info) list) list ->
+    unit Current.t
+    (** [repo ~channel ~web_ui ~org ~name builds] is an OCurrent pipeline to
+        handle all builds and deployments under [org/name]. Each build
+        is a [(build_info, [branch, deploy_info])] pair.
+        It builds every branch and PR using [T.build], and deploys the
+        given branches using [T.deploy], sending notifications to [channel]. *)
+end

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -1,5 +1,3 @@
-open Current.Syntax
-
 module Github = Current_github
 
 let timeout = Duration.of_min 50    (* Max build time *)
@@ -7,30 +5,39 @@ let timeout = Duration.of_min 50    (* Max build time *)
 module Toxis_service = struct
   (* Docker services running on toxis. *)
 
-  type t = {
+  module Docker = Current_docker.Default
+
+  type build_info = {
+    dockerfile : string;
+  }
+
+  type binary = Docker.Image.t
+
+  type deploy_info = {
     service : string;
     tag : string;
   }
 
-  module Docker = Current_docker.Default
-
   (* Build [src/dockerfile] as a Docker service. *)
-  let build ~dockerfile src =
+  let build { dockerfile } src =
     Docker.build (`Git src)
       ~label:dockerfile
       ~dockerfile:(Current.return (`File (Fpath.v dockerfile)))
       ~pull:true
       ~timeout
 
+  let name info = info.service
+
   (* Update Docker service [service] to [image].
      We also tag it, so that if someone redeploys the stack.yml then it will
      still use this version. *)
-  let deploy ~tag ~service image =
+  let deploy { tag; service } image =
     Current.all [
       Docker.tag ~tag image;
       Docker.service ~name:service ~image ()
     ]
 end
+module Build_toxis = Build.Make(Toxis_service)
 
 module Packet_unikernel = struct
   (* Mirage unikernels running on packet.net *)
@@ -40,8 +47,19 @@ module Packet_unikernel = struct
   module Docker = Current_docker.Default
   module Mirage_m1_a = Mirage.Make(Docker)
 
+  type build_info = {
+    dockerfile : string;
+    args : string list;
+  }
+
+  type binary = Docker.Image.t
+
+  type deploy_info = {
+    service : string;
+  }
+
   (* Build [src/dockerfile] as an HVT unikernel. *)
-  let build ~dockerfile src args =
+  let build  { dockerfile; args } src =
     let build_args = List.map (fun x -> ["--build-arg"; x]) args |> List.concat in
     let dockerfile = Current.return (`File (Fpath.v dockerfile)) in
     Docker.build (`Git src)
@@ -50,9 +68,12 @@ module Packet_unikernel = struct
       ~pull:true
       ~timeout
 
-  let deploy service =
-    Mirage_m1_a.deploy ~name:service ~ssh_host:mirage_host_ssh
+  let name { service } = service
+
+  let deploy { service } image =
+    Mirage_m1_a.deploy ~name:service ~ssh_host:mirage_host_ssh image
 end
+module Build_unikernel = Build.Make(Packet_unikernel)
 
 (* [web_ui collapse_value] is a URL back to the deployment service, for links
    in status messages. *)
@@ -60,41 +81,19 @@ let web_ui =
   let base = Uri.of_string "https://deploy.ocamllabs.io/" in
   fun repo -> Uri.with_query' base ["repo", repo]
 
-(* Push a Slack notification to [channel] to say that [x] is updating [service] to [commit].
-   [repo] is used for the URL in the message. *)
-let notify ~channel ~service ~commit ~repo x =
-  let s =
-    let+ state = Current.state x
-    and+ commit = commit in
-    let uri = Github.Api.Commit.uri commit in
-    Fmt.strf "@[<h>Deploy <%a|%a> as %s: <%s|%a>@]"
-      Uri.pp uri Github.Api.Commit.pp commit
-      service
-      (Uri.to_string (web_ui repo)) (Current_term.Output.pp Current.Unit.pp) state
-  in
-  Current.all [
-    Current_slack.post channel ~key:("deploy-" ^ service) s;
-    x   (* If [x] fails, the whole pipeline should fail too. *)
-  ]
+let docker dockerfile services =
+  let build_info = { Toxis_service.dockerfile } in
+  let deploys =
+    services
+    |> List.map (fun (branch, tag, service) -> branch, { Toxis_service.tag; service }) in
+  (build_info, deploys)
 
-(* Build [src/dockerfile]. *)
-let build ~dockerfile ~src = function
-  | `Docker -> Current.ignore_value (Toxis_service.build src ~dockerfile)
-  | `Unikernel flags -> Current.ignore_value (Packet_unikernel.build src ~dockerfile flags)
-
-(* Build and deploy [src/dockerfile]. *)
-let deploy ~channel ~dockerfile ~src ~commit ~collapse_value = function
-  | `Docker { Toxis_service.service; tag } ->
-    Toxis_service.build src ~dockerfile
-    |> Toxis_service.deploy ~service ~tag
-    |> notify ~channel ~service ~commit ~repo:collapse_value
-  | `Unikernel (service, flags) ->
-    Packet_unikernel.build src ~dockerfile flags
-    |> Packet_unikernel.deploy service
-    |> notify ~channel ~service ~commit ~repo:collapse_value
-
-let docker ~service ~tag = `Docker { Toxis_service.service; tag }
-let unikernel ~service args = `Unikernel (service, args)
+let unikernel dockerfile args services =
+  let build_info = { Packet_unikernel.dockerfile; args } in
+  let deploys =
+    services
+    |> List.map (fun (branch, service) -> branch, { Packet_unikernel.service }) in
+  (build_info, deploys)
 
 (* This is a list of GitHub repositories to monitor.
    For each one, it lists the deployments that are made from that repository.
@@ -105,24 +104,28 @@ let unikernel ~service args = `Unikernel (service, args)
 let v ~app ~notify:channel () =
   let ocurrent = Build.org ~app ~account:"ocurrent" 6853813 in
   let mirage = Build.org ~app ~account:"mirage" 7175142 in
-  let repo (org, name, builds) =
-    Build.repo ~web_ui ~deploy:(deploy ~channel) ~build ~org ~name builds
+  let docker_services = 
+    let build (org, name, builds) = Build_toxis.repo ~channel ~web_ui ~org ~name builds in
+    Current.all @@ List.map build [
+      (* OCurrent repositories *)
+      ocurrent, "ocaml-ci", [
+        docker "Dockerfile"     ["live-engine", "ocaml-ci-service:latest", "ocaml-ci_ci"];
+        docker "Dockerfile.web" ["live-www",    "ocaml-ci-web:latest",     "ocaml-ci_web";
+                                 "staging-www", "ocaml-ci-web:staging",    "test-www"];
+      ];
+      ocurrent, "ocurrent-deployer", [
+        docker "Dockerfile"     ["live", "ci.ocamllabs.io-deployer:latest", "infra_deployer"];
+      ];
+      ocurrent, "docker-base-images", [
+        docker "Dockerfile"     ["live", "base-images:latest", "base-images_builder"];
+      ]
+    ]
+  and mirage_unikernels =
+    let build (org, name, builds) = Build_unikernel.repo ~channel ~web_ui ~org ~name builds in
+    Current.all @@ List.map build [
+      mirage, "mirage-www", [
+        unikernel "Dockerfile" ["TARGET=hvt"; "EXTRA_FLAGS=--tls=true"] ["master", "www"];
+      ];
+    ]
   in
-  Current.all @@ List.map repo [
-    (* OCurrent repositories *)
-    ocurrent, "ocaml-ci", [
-      "Dockerfile",     "live-engine", docker ~tag:"ocaml-ci-service:latest" ~service:"ocaml-ci_ci";
-      "Dockerfile.web", "live-www",    docker ~tag:"ocaml-ci-web:latest"     ~service:"ocaml-ci_web";
-      "Dockerfile.web", "staging-www", docker ~tag:"ocaml-ci-web:staging"    ~service:"test-www";
-    ];
-    ocurrent, "ocurrent-deployer", [
-      "Dockerfile", "live", docker ~tag:"ci.ocamllabs.io-deployer:latest" ~service:"infra_deployer";
-    ];
-    ocurrent, "docker-base-images", [
-      "Dockerfile", "live", docker ~tag:"base-images:latest" ~service:"base-images_builder";
-    ];
-    (* Mirage repositories *)
-    mirage, "mirage-www", [
-      "Dockerfile", "master", unikernel ~service:"www" ["TARGET=hvt"; "EXTRA_FLAGS=--tls=true"];
-    ];
-  ]
+  Current.all [ docker_services; mirage_unikernels ]

--- a/src/s.ml
+++ b/src/s.ml
@@ -1,0 +1,16 @@
+module type T = sig
+  type build_info
+  type binary
+  type deploy_info
+
+  val build :
+    build_info ->
+    Current_git.Commit.t Current.t -> binary Current.t
+
+  val name : deploy_info -> string
+  (** A unique service name to use in the Slack notifications and URLs. *)
+
+  val deploy :
+    deploy_info ->
+    binary Current.t -> unit Current.t
+end


### PR DESCRIPTION
Instead of trying to make the build code work with both Docker services and unikernels, provide a functor that can be used with whatever types you like.