### PR TITLE
Revert "Work around race in mirage tool"

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -138,7 +138,7 @@ let v ~app ~notify:channel () =
     let build (org, name, builds) = Build_unikernel.repo ~channel ~web_ui ~org ~name builds in
     Current.all @@ List.map build [
       mirage, "mirage-www", [
-        unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --interface=service"] ["master", "www"];
+        unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true"] ["master", "www"];
         unikernel "Dockerfile" ~target:"xen" ["EXTRA_FLAGS=--tls=true"] [];     (* (no deployments) *)
       ];
     ]


### PR DESCRIPTION
This reverts commit 7e76e043f9f52a09b09983279a957899f297907c. It's not needed since https://github.com/mirage/mirage-www/pull/680.