### PR TITLE
Make deployment system more flexible

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -70,8 +70,7 @@ module Make(T : S.T) = struct
                   let collapse_value = Printf.sprintf "%s-%s-%s" repo_name service branch in
                   let commit = head_of ~github repo branch in
                   let src = Git.fetch (Current.map Github.Api.Commit.id commit) in
-                  let binary = T.build build_info src in
-                  T.deploy deploy_info binary
+                  T.deploy build_info deploy_info src
                   |> notify ~channel ~web_ui ~service ~commit ~repo:collapse_value
                   |> Current.collapse
                     ~key:"repo" ~value:collapse_value

--- a/src/main.ml
+++ b/src/main.ml
@@ -3,11 +3,14 @@
 
 let () = Logging.init ()
 
+let read_first_line path =
+  let ch = open_in path in
+  Fun.protect (fun () -> input_line ch)
+    ~finally:(fun () -> close_in ch)
+
 let read_channel_uri path =
   try
-    let ch = open_in path in
-    let uri = input_line ch in
-    close_in ch;
+    let uri = read_first_line path in
     Current_slack.channel (Uri.of_string (String.trim uri))
   with ex ->
     Fmt.failwith "Failed to read slack URI from %S: %a" path Fmt.exn ex

--- a/src/s.ml
+++ b/src/s.ml
@@ -1,16 +1,16 @@
 module type T = sig
   type build_info
-  type binary
   type deploy_info
 
   val build :
     build_info ->
-    Current_git.Commit.t Current.t -> binary Current.t
+    Current_git.Commit.t Current.t -> unit Current.t
 
   val name : deploy_info -> string
   (** A unique service name to use in the Slack notifications and URLs. *)
 
   val deploy :
+    build_info ->
     deploy_info ->
-    binary Current.t -> unit Current.t
+    Current_git.Commit.t Current.t -> unit Current.t
 end


### PR DESCRIPTION
Instead of passing the result of the build step to the deploy, give the source and build info to the deploy function directly. It can just call the build step itself if it wants to, but it can also behave differently.

This will be useful with the new build scheduler, because we need to know whether we're deploying to decide whether to save the resulting image.