### PR TITLE
configure ocaml.org to include git

### DIFF
--- a/deployer.opam
+++ b/deployer.opam
@@ -7,6 +7,9 @@ homepage: "https://github.com/ocurrent/ocurrent-deployer"
 bug-reports: "https://github.com/ocurrent/ocurrent-deployer/issues"
 depends: [
   "dune" {>= "1.11"}
+  "ppx_deriving_yojson"
+  "ppx_deriving"
+  "logs"
   "current"
   "current_web"
   "current_git"

--- a/dune-project
+++ b/dune-project
@@ -1,16 +1,16 @@
 (lang dune 1.11)
 (name deployer)
-
 (generate_opam_files true)
-
 (source (github ocurrent/ocurrent-deployer))
 (authors "talex5@gmail.com")
 (maintainers "talex5@gmail.com")
-
 (package
  (name deployer)
  (synopsis "Deploy other pipelines")
  (depends
+  ppx_deriving_yojson
+  ppx_deriving
+  logs
   current
   current_web
   current_git

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -92,6 +92,7 @@ module Cluster = struct
   type build_info = {
     sched : Current_ocluster.t;
     dockerfile : [`Contents of string Current.t | `Path of string];
+    options : Cluster_api.Docker.Spec.options;
     archs : arch list;
   }
 
@@ -106,9 +107,8 @@ module Cluster = struct
   }
 
   (* Build [src/dockerfile] as a Docker service. *)
-  let build { sched; dockerfile; archs } src =
+  let build { sched; dockerfile; options; archs } src =
     let src = Current.map (fun x -> [x]) src in
-    let options = Cluster_api.Docker.Spec.defaults in
     let build_arch arch = Current_ocluster.build sched ~options ~pool:(pool_id arch) ~src dockerfile in
     Current.all (List.map build_arch archs)
 
@@ -133,14 +133,13 @@ module Cluster = struct
           Caddy.replace_hash_var ~hash:(D.Image.hash image) contents) image in
         D.compose ~name ~contents ()
 
-  let deploy { sched; dockerfile; archs } { hub_id; services } src =
+  let deploy { sched; dockerfile; options; archs } { hub_id; services } src =
     let src = Current.map (fun x -> [x]) src in
     let target_label = Cluster_api.Docker.Image_id.repo hub_id |> String.map (function '/' | ':' -> '-' | c -> c) in
     let build_arch arch =
       let pool = pool_id arch in
       let tag = Printf.sprintf "live-%s-%s" target_label pool in
       let push_target = Cluster_api.Docker.Image_id.v ~repo:push_repo ~tag in
-      let options = Cluster_api.Docker.Spec.defaults in
       Current_ocluster.build_and_push sched ~options ~push_target ~pool ~src dockerfile
     in
     let images = List.map build_arch archs in
@@ -171,8 +170,8 @@ let web_ui =
   let base = Uri.of_string "https://deploy.ocamllabs.io/" in
   fun repo -> Uri.with_query' base ["repo", repo]
 
-let docker ?(archs=[`Linux_x86_64]) ~sched dockerfile targets =
-  let build_info = { Cluster.sched; dockerfile = `Path dockerfile; archs } in
+let docker ?(archs=[`Linux_x86_64]) ?(options=Cluster_api.Docker.Spec.defaults) ~sched dockerfile targets =
+  let build_info = { Cluster.sched; dockerfile = `Path dockerfile; options; archs } in
   let deploys =
     targets
     |> List.map (fun (branch, target, services) ->
@@ -221,8 +220,8 @@ let v ~app ~notify:channel ~sched ~staging_auth () =
           ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64];
       ];
       ocaml, "ocaml.org", [
-        docker "Dockerfile.deploy" ["master", "ocurrent/ocaml.org:live", [`C (`Ocamlorg_sw, ["www.ocaml.org", "51.159.79.75"; "ocaml.org", "51.159.78.124"])]];
-        docker "Dockerfile.staging" ["staging","ocurrent/ocaml.org:staging", [`C (`Ocamlorg_sw, ["staging.ocaml.org", "51.159.79.64"])]]
+        docker ~options:{ Cluster_api.Docker.Spec.defaults with include_git = true } "Dockerfile.deploy" ["master", "ocurrent/ocaml.org:live", [`C (`Ocamlorg_sw, ["www.ocaml.org", "51.159.79.75"; "ocaml.org", "51.159.78.124"])]];
+        docker ~options:{ Cluster_api.Docker.Spec.defaults with include_git = true } "Dockerfile.staging" ["staging","ocurrent/ocaml.org:staging", [`C (`Ocamlorg_sw, ["staging.ocaml.org", "51.159.79.64"])]]
       ];
     ]
   and mirage_unikernels =

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -198,6 +198,7 @@ let v ~app ~notify:channel ~sched ~staging_auth () =
   let ocurrent = Build.org ~app ~account:"ocurrent" 6853813 in
   let mirage = Build.org ~app ~account:"mirage" 7175142 in
   let ocaml = Build.org ~app ~account:"ocaml" 12075891 in
+  let include_git = { Cluster_api.Docker.Spec.defaults with include_git = true } in
   let docker_services =
     let build (org, name, builds) = Cluster_build.repo ~channel ~web_ui ~org ~name builds in
     let sched = Current_ocluster.v ~timeout ?push_auth:staging_auth sched in
@@ -220,8 +221,10 @@ let v ~app ~notify:channel ~sched ~staging_auth () =
           ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64];
       ];
       ocaml, "ocaml.org", [
-        docker ~options:{ Cluster_api.Docker.Spec.defaults with include_git = true } "Dockerfile.deploy" ["master", "ocurrent/ocaml.org:live", [`C (`Ocamlorg_sw, ["www.ocaml.org", "51.159.79.75"; "ocaml.org", "51.159.78.124"])]];
-        docker ~options:{ Cluster_api.Docker.Spec.defaults with include_git = true } "Dockerfile.staging" ["staging","ocurrent/ocaml.org:staging", [`C (`Ocamlorg_sw, ["staging.ocaml.org", "51.159.79.64"])]]
+        docker "Dockerfile.deploy"  ["master", "ocurrent/ocaml.org:live", [`C (`Ocamlorg_sw, ["www.ocaml.org", "51.159.79.75"; "ocaml.org", "51.159.78.124"])]]
+          ~options:include_git;
+        docker "Dockerfile.staging" ["staging","ocurrent/ocaml.org:staging", [`C (`Ocamlorg_sw, ["staging.ocaml.org", "51.159.79.64"])]]
+          ~options:include_git;
       ];
     ]
   and mirage_unikernels =


### PR DESCRIPTION
This PR should hopefully fix https://github.com/ocaml/ocaml.org/issues/1247 (related work on https://github.com/ocaml/ocaml.org/pull/1253) in which the `git log` command for getting the contributors of the ocaml.org site failed in production/staging but not locally. 

This is likely caused by using the default `Docker.Spec` build context which excludes `.git`. Here it has been enabled for the ocaml.org production and staging deployments.

The `.git` directory shouldn't make it to the server as we copy over the build from another build stage in the Dockerfile https://github.com/ocaml/ocaml.org/blob/master/Dockerfile.deploy#L13