### PR TITLE
Docs-ci: add git-http-website deployment

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -221,6 +221,9 @@ let v ~app ~notify:channel ~sched ~staging_auth () =
         docker "docker/init/Dockerfile"     ["live", "ocurrent/docs-ci-init:live", [`Ci6, "infra_init"]];
         docker "docker/storage/Dockerfile"  ["live", "ocurrent/docs-ci-storage-server:live", [`Ci6, "infra_storage-server"]];
         docker "docker/git-http/Dockerfile" ["live", "ocurrent/docs-ci-git-http:live", [`Ci6, "infra_git-http"]];
+        docker "docker/git-http-website/Dockerfile" 
+                                            ["live", "ocurrent/docs-ci-git-http-website:live", [`Ci6, "infra_git-http-tailwind-website"; 
+                                                                                                `Ci6, "infra_git-http-classic-website"]];
         docker "Dockerfile.web"             ["live-web", "ocurrent/docs-ci-web:live", [`Ci6, "infra_docs-ci-web"]];
       ];
     ]


### PR DESCRIPTION
This image will be added in https://github.com/ocurrent/ocaml-docs-ci/pull/35
As documentation is stored in a git repository, there's not straightforward access to the data (except by `git` cloning and merging).
We use an http server based on ocaml-git to expose the files and explore the output. 