### PR TITLE
ocaml-docs-ci: remove the deployment of docs-ci-web

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -197,7 +197,6 @@ let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
       docker "Dockerfile"                 ["live", "ocurrent/docs-ci:live", [`Ci6 "infra_docs-ci"]];
       docker "docker/init/Dockerfile"     ["live", "ocurrent/docs-ci-init:live", [`Ci6 "infra_init"]];
       docker "docker/storage/Dockerfile"  ["live", "ocurrent/docs-ci-storage-server:live", [`Ci6 "infra_storage-server"]];
-      docker "Dockerfile.web"             ["live-web", "ocurrent/docs-ci-web:live", [`Ci6 "infra_docs-ci-web"]];
     ];
     ocurrent, "current-bench", [
       docker "pipeline/Dockerfile" ["live", "ocurrent/current-bench-pipeline:live", [`Autumn "current-bench_pipeline"]];


### PR DESCRIPTION
Because of the new v3.ocaml.org deployment, the build of `Dockerfile.web` deployed as `docs-ci-web` is not relevant anymore.