### PR TITLE
Update ocurrent to latest version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \
 	ocurrent/current_git.opam \
-	ocurrent/current_incr.opam \
 	ocurrent/current.opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_slack.opam \
@@ -18,7 +17,6 @@ WORKDIR /src
 RUN opam pin add -yn current_docker.dev "./ocurrent" && \
     opam pin add -yn current_github.dev "./ocurrent" && \
     opam pin add -yn current_git.dev "./ocurrent" && \
-    opam pin add -yn current_incr.dev "./ocurrent" && \
     opam pin add -yn current.dev "./ocurrent" && \
     opam pin add -yn current_rpc.dev "./ocurrent" && \
     opam pin add -yn current_slack.dev "./ocurrent" && \

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ See [VM-host.md](./VM-host.md) for instructions about setting up a host for unik
 To test changes to the pipeline, use:
 
 ```
-dune exec -- ocurrent-deployer-local --confirm=harmless --submission-service submission.cap ocurrent/ocaml-ci
+dune exec -- ocurrent-deployer-local --confirm=harmless --submission-service submission.cap ocurrent/ocaml-ci \
+                                     --github-webhook-secret-file github-secret-file
 ```
 
 You will need a `submission.cap` to access an [OCluster build cluster](https://github.com/ocurrent/ocluster)
-(you can run one locally fairly easily if needed).
+(you can run one locally fairly easily if needed), along with a `github-secret-file` containing a valid GitHub
+secret for [securing webhooks](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks).
 
 Replace `ocurrent/ocaml-ci` with the GitHub repository you want to check, or omit it to check all of them.
 
@@ -53,7 +55,7 @@ Unlike the full pipeline, this:
 - Uses anonymous access to get the branch heads.
 
 You can supply `--github-app-id` and related options if you want to access GitHub via an app
-(this gives a higher rate limit for queries and allows setting the result status).
+(this gives a higher rate limit for queries, allows setting the result status and handling GitHub webhooks).
 
 ## Suggested workflows
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -52,9 +52,9 @@ module Make(T : S.T) = struct
   let status_of_build ~url b =
     let+ state = Current.state b in
     match state with
-    | Ok _              -> Github.Api.CheckRunStatus.v ~url (`Completed `Success) ~description:"Passed"
+    | Ok _              -> Github.Api.CheckRunStatus.v ~url (`Completed `Success) ~summary:"Passed"
     | Error (`Active _) -> Github.Api.CheckRunStatus.v ~url `Queued
-    | Error (`Msg m)    -> Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~description:m
+    | Error (`Msg m)    -> Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~summary:m
 
   let repo ?channel ~web_ui ~org:(org, github) ~name build_specs =
     let repo_name = Printf.sprintf "%s/%s" org name in

--- a/src/main.ml
+++ b/src/main.ml
@@ -39,13 +39,14 @@ let main config mode app slack auth sched staging_password_file =
   let staging_auth = staging_password_file |> Option.map (fun path -> staging_user, read_first_line path) in
   let engine = Current.Engine.create ~config (Pipeline.v ~app ~notify:channel ~sched ~staging_auth) in
   let authn = Option.map Current_github.Auth.make_login_uri auth in
+  let webhook_secret = Current_github.App.webhook_secret app in
   let has_role =
     if auth = None then Current_web.Site.allow_all
     else has_role
   in
   let routes =
     Routes.(s "login" /? nil @--> Current_github.Auth.login auth) ::
-    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~webhook_secret ~has_role) ::
     Current_web.routes engine in
   let site = Current_web.Site.v ?authn ~has_role ~name:"OCurrent Deployer" routes in
   Logging.run begin


### PR DESCRIPTION
Includes with Checks API setting more details and support for rebuilding jobs.

Brings in the requirement to set `--github-webhook-secret-file` to validate web hooks.