### PR TITLE
Increase timeout for opam2web.

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -384,7 +384,7 @@ let ocaml_org ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
   let opam_repository_pipeline = filter_list filter [
     ocaml_opam, "opam2web", [
-      docker_with_timeout (Duration.of_min 180)
+      docker_with_timeout (Duration.of_min 240)
         "Dockerfile" [ "live", "ocurrent/opam.ocaml.org:live", [`Ocamlorg_opam "infra_opam_live"]
                      ; "live-staging", "ocurrent/opam.ocaml.org:staging", [`Ocamlorg_opam "infra_opam_staging"]]
         ~options:(include_git |> build_kit)


### PR DESCRIPTION
The large image pushes to docker are sometimes timing out.