### PR TITLE
Wiring in check-run and check-suite support.

### DIFF
--- a/deployer.opam
+++ b/deployer.opam
@@ -6,7 +6,7 @@ authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocurrent/ocurrent-deployer"
 bug-reports: "https://github.com/ocurrent/ocurrent-deployer/issues"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "2.0"}
   "ppx_deriving_yojson"
   "ppx_deriving"
   "logs"
@@ -22,6 +22,8 @@ depends: [
   "lwt"
   "cmdliner" {>= "1.1.0"}
   "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.0.0" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.11)
+(lang dune 2.0)
 (name deployer)
 (generate_opam_files true)
 (source (github ocurrent/ocurrent-deployer))
@@ -22,4 +22,6 @@
   fmt
   lwt
   (cmdliner (>= 1.1.0))
-  (ocaml (>= 4.08.0))))
+  (ocaml (>= 4.08.0))
+  (alcotest (and (>= 1.0.0) :with-test))
+  (alcotest-lwt (and (>= 1.0.1) :with-test))))

--- a/dune-project
+++ b/dune-project
@@ -4,6 +4,7 @@
 (source (github ocurrent/ocurrent-deployer))
 (authors "talex5@gmail.com")
 (maintainers "talex5@gmail.com")
+(formatting disabled)
 (package
  (name deployer)
  (synopsis "Deploy other pipelines")

--- a/src/build.ml
+++ b/src/build.ml
@@ -74,7 +74,7 @@ module Make(T : S.T) = struct
           |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
           let src = Current.map Github.Api.Commit.id commit in
           Current.all (
-            build_specs |> List.map (fun (build_info, _deploys) -> T.build ?additional_build_args build_info src |> Current.ignore_value)
+            build_specs |> List.map (fun (build_info, _deploys) -> T.build ?additional_build_args build_info repo src |> Current.ignore_value)
           )
           |> status_of_build ~url
           |> Github.Api.CheckRun.set_status commit "deployability"

--- a/src/dune
+++ b/src/dune
@@ -12,6 +12,7 @@
    current_slack
    current_web
    cmdliner
+   deployer
    fmt.tty
    fmt.cli
    logs.fmt
@@ -19,4 +20,29 @@
    str
    lwt
    lwt.unix)
+ (modules main local)
+ (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
+
+(library
+ (name deployer)
+ (public_name deployer)
+ (libraries
+   capnp-rpc-unix
+   current
+   current.cache
+   current_git
+   current_github
+   current_docker
+   current_ocluster
+   current_slack
+   current_web
+   cmdliner
+   fmt.tty
+   fmt.cli
+   logs.fmt
+   logs.cli
+   str
+   lwt
+   lwt.unix)
+ (modules index pipeline caddy logging mirage s build)
  (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/src/index.ml
+++ b/src/index.ml
@@ -1,0 +1,107 @@
+let src = Logs.Src.create "deployer.index" ~doc:"deployer indexer"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Db = Current.Db
+
+module Job_map = Astring.String.Map
+
+type t = {
+  db : Sqlite3.db;
+  record_job : Sqlite3.stmt;
+  remove : Sqlite3.stmt;
+  get_jobs : Sqlite3.stmt;
+  get_job : Sqlite3.stmt;
+  get_job_ids : Sqlite3.stmt;
+  full_hash : Sqlite3.stmt;
+}
+
+let or_fail label x =
+  match x with
+  | Sqlite3.Rc.OK -> ()
+  | err -> Fmt.failwith "Sqlite3 %s error: %s" label (Sqlite3.Rc.to_string err)
+
+let db = lazy (
+  let db = Lazy.force Current.Db.v in
+  Current_cache.Db.init ();
+  Sqlite3.exec db {|
+CREATE TABLE IF NOT EXISTS deployer_index (
+  owner     TEXT NOT NULL,
+  name      TEXT NOT NULL,
+  hash      TEXT NOT NULL,
+  variant   TEXT NOT NULL,
+  job_id    TEXT,
+  PRIMARY KEY (owner, name, hash, variant)
+)|} |> or_fail "create table";
+  let record_job = Sqlite3.prepare db "INSERT OR REPLACE INTO deployer_index \
+                                     (owner, name, hash, variant, job_id) \
+                                     VALUES (?, ?, ?, ?, ?)" in
+  let remove = Sqlite3.prepare db "DELETE FROM deployer_index \
+                                     WHERE owner = ? AND name = ? AND hash = ? AND variant = ?" in
+  let get_jobs = Sqlite3.prepare db "SELECT deployer_index.variant, deployer_index.job_id, cache.ok, cache.outcome \
+                                     FROM deployer_index \
+                                     LEFT JOIN cache ON deployer_index.job_id = cache.job_id \
+                                     WHERE deployer_index.owner = ? AND deployer_index.name = ? AND deployer_index.hash = ?" in
+  let get_job = Sqlite3.prepare db "SELECT job_id FROM deployer_index \
+                                     WHERE owner = ? AND name = ? AND hash = ? AND variant = ?" in
+  let get_job_ids = Sqlite3.prepare db "SELECT variant, job_id FROM deployer_index \
+                                     WHERE owner = ? AND name = ? AND hash = ?" in
+  let full_hash = Sqlite3.prepare db "SELECT DISTINCT hash FROM deployer_index \
+                                      WHERE owner = ? AND name = ? AND hash LIKE ?" in
+      {
+        db;
+        record_job;
+        remove;
+        get_jobs;
+        get_job;
+        get_job_ids;
+        full_hash
+      }
+)
+
+let init () = ignore (Lazy.force db)
+
+let get_job_ids_with_variant t ~owner ~name ~hash =
+  Db.query t.get_job_ids Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
+  |> List.map @@ function
+  | Sqlite3.Data.[ TEXT variant; NULL ] -> variant, None
+  | Sqlite3.Data.[ TEXT variant; TEXT id ] -> variant, Some id
+  | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
+
+let record ~repo ~hash jobs =
+  let { Current_github.Repo_id.owner; name } = repo in
+  let t = Lazy.force db in
+  let jobs = Job_map.of_list jobs in
+  let previous = get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list in
+  let merge variant prev job =
+    let set job_id =
+      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s -> %a@]"
+                   owner name (Astring.String.with_range ~len:6 hash) variant Fmt.(option ~none:(any "-") string) job_id);
+      match job_id with
+      | None -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; NULL ]
+      | Some id -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT id ]
+    in
+    let update j1 j2 =
+      match j1, j2 with
+      | Some j1, Some j2 when j1 = j2 -> ()
+      | None, None -> ()
+      | _, j2 -> set j2
+    in
+    let remove () =
+      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s REMOVED@]"
+                   owner name (Astring.String.with_range ~len:6 hash) variant);
+      Db.exec t.remove Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+    in
+    begin match prev, job with
+      | Some j1, Some j2 -> update j1 j2
+      | None, Some j2 -> set j2
+      | Some _, None -> remove ()
+      | None, None -> assert false
+    end;
+    None
+  in
+  let _ : [`Empty] Job_map.t = Job_map.merge merge previous jobs in
+  ()
+
+let get_job_ids  ~owner ~name ~hash =
+  let t = Lazy.force db in
+  get_job_ids_with_variant t ~owner ~name ~hash |> List.filter_map snd

--- a/src/index.mli
+++ b/src/index.mli
@@ -1,0 +1,15 @@
+(** The index is:
+    - A (persisted) map from each Git commit hash to its last known OCurrent job ID. *)
+
+val init : unit -> unit
+(** Ensure the database is initialised (for unit-tests). *)
+
+val record :
+  repo:Current_github.Repo_id.t ->
+  hash:string ->
+  (string * Current.job_id option) list ->
+  unit
+(** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
+
+val get_job_ids: owner:string -> name:string -> hash:string -> string list
+(** list of job_ids that correspond to (owner, name, commit)*)

--- a/src/local.ml
+++ b/src/local.ml
@@ -2,6 +2,8 @@
 
 (* A low-security Docker Hub user used to push images to the staging area.
    Low-security because we never rely on the tags in this repository, just the hashes. *)
+open Deployer
+
 let staging_user = "ocurrentbuilder"
 
 (* Placeholder webhook_secret, when running in local mode. *)
@@ -13,6 +15,7 @@ let read_first_line path =
     ~finally:(fun () -> close_in ch)
 
 let main () config mode app sched staging_password_file repo flavour =
+  Logs.info (fun f -> f "Is this thing on?");
   let filter = Option.map (=) repo in
   let vat = Capnp_rpc_unix.client_only_vat () in
   let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
@@ -25,7 +28,7 @@ let main () config mode app sched staging_password_file repo flavour =
   let webhook_secret = Option.value ~default:webhook_secret @@ Option.map Current_github.App.webhook_secret app in
   let has_role = Current_web.Site.allow_all in
   let routes =
-    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~webhook_secret ~has_role) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~get_job_ids:Index.get_job_ids ~webhook_secret ~has_role) ::
     Current_web.routes engine in
   let site = Current_web.Site.v ~has_role ~name:"OCurrent Deployer" routes in
   Logging.run begin

--- a/src/main.ml
+++ b/src/main.ml
@@ -1,5 +1,7 @@
 (* This is the main entry-point for the service. *)
 
+open Deployer
+
 type flavour_opt =
   | Tarides of Uri.t
   | OCaml of Uri.t
@@ -96,7 +98,7 @@ let main () config mode app slack auth staging_password_file flavour =
   in
   let routes =
     Routes.(s "login" /? nil @--> Current_github.Auth.login auth) ::
-    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~webhook_secret ~has_role) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~get_job_ids:Index.get_job_ids ~webhook_secret ~has_role) ::
     Current_web.routes engine in
   let site = Current_web.Site.v ?authn ~has_role ~name:"OCurrent Deployer" routes in
   Logging.run begin

--- a/src/s.ml
+++ b/src/s.ml
@@ -5,6 +5,7 @@ module type T = sig
   val build :
     build_info ->
     ?additional_build_args:string list Current.t ->
+    Current_github.Repo_id.t ->
     Current_git.Commit_id.t Current.t -> unit Current.t
 
   val name : deploy_info -> string

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,11 @@
+(test
+ (name test)
+ (package deployer)
+ (libraries deployer alcotest alcotest-lwt ppx_deriving_yojson.runtime logs.fmt)
+ (preprocess (pps ppx_deriving.eq ppx_deriving_yojson)))
+
+(rule
+  (alias runtest)
+  (package deployer)
+  (deps (package deployer))
+  (action (run ./test.exe)))

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,5 @@
-(test
+(executable
  (name test)
- (package deployer)
  (libraries deployer alcotest alcotest-lwt ppx_deriving_yojson.runtime logs.fmt)
  (preprocess (pps ppx_deriving.eq ppx_deriving_yojson)))
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,8 @@
+let () =
+  Unix.putenv "HOME" "/idontexist";        (* Ignore user's git configuration *)
+  Unix.putenv "GIT_AUTHOR_NAME" "test";
+  Unix.putenv "GIT_COMMITTER_NAME" "test";
+  Unix.putenv "EMAIL" "test@example.com";
+  Lwt_main.run
+  @@ Alcotest_lwt.run "deployer"
+       [ ("index", Test_index.tests); ]

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -1,0 +1,18 @@
+module Index = Deployer.Index
+
+let test_simple () =
+  let owner = "owner" in
+  let name = "name" in
+  let repo = { Current_github.Repo_id.owner; name } in
+  let hash = "abc" in
+  let _ = Lazy.force Current.Db.v in
+  Index.init ();
+  Index.record ~repo ~hash [ ("build", Some "job1"); ("deploy", None) ];
+  Alcotest.(check (list string)) "Job-ids" ["job1"] @@ Index.get_job_ids ~owner ~name ~hash;
+  Index.record ~repo ~hash [ ("build", Some "job2") ];
+  Alcotest.(check (list string)) "Job-ids" ["job2"] @@ List.sort String.compare @@ Index.get_job_ids ~owner ~name ~hash
+
+let tests = [
+    Alcotest_lwt.test_case_sync "simple" `Quick test_simple;
+]
+


### PR DESCRIPTION
This requires supporting persistence
in SQLite so that we can lookup job-ids
that correspond to a commit.

Dependent on https://github.com/ocurrent/ocurrent/pull/364 and updating ocurrent to point to latest master once this is merged.