### PR TITLE
Added AWS ECS pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocurrent-deployer
 
 FROM debian:11
-RUN apt-get update && apt-get install libffi-dev libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase rsync -y --no-install-recommends
+RUN apt-get update && apt-get install libffi-dev libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase rsync awscli -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 RUN apt-get update && apt-get install python3-pip -y && pip3 install docker-compose --no-cache-dir
+RUN curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocurrent-deployer"]
 COPY config/ssh /root/.ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ FROM debian:11
 RUN apt-get update && apt-get install libffi-dev libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase rsync awscli -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
-RUN apt-get update && apt-get install python3-pip -y && pip3 install docker-compose --no-cache-dir
+RUN apt-get update && apt-get install docker-ce docker-ce-cli docker-compose-plugin -y --no-install-recommends
 RUN curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocurrent-deployer"]

--- a/config/docker/contexts/meta/2b2d409edce7cf1d000adf0d93ec45c8affa00363cc0cee5b647e860ef2d49ec/meta.json
+++ b/config/docker/contexts/meta/2b2d409edce7cf1d000adf0d93ec45c8affa00363cc0cee5b647e860ef2d49ec/meta.json
@@ -1,0 +1,1 @@
+{"Name":"awsecs","Metadata":{"Type":"ecs"},"Endpoints":{"docker":{"Profile":"default"},"ecs":{"Profile":"default"}}}

--- a/src/aws.ml
+++ b/src/aws.ml
@@ -1,0 +1,94 @@
+(* Compose configuration for a AWS ECS *)
+
+type t = {
+  name: string;
+  branch: string;
+  vcpu: float;
+  memory: int;
+  storage: int option;
+  replicas: int;
+  command: string option;
+  port: int;
+  certificate: string;
+}
+
+let command_colon = function
+  | None -> ""
+  | Some cmd -> "    command: " ^ cmd ^ "\n"
+
+let storage_colon n gb =
+  match gb with
+  | None -> ""
+  | Some gb -> Fmt.str {|    %sTaskDefinition:
+      Properties:
+        EphemeralStorage:
+          SizeInGiB: %i
+|} n gb
+
+let compose s =
+  let capitalized_branch = String.capitalize_ascii s.branch in
+  let service = Fmt.str {|
+version: "3.4"
+services:
+  %s:
+    image: $IMAGE_HASH
+%s    ports:
+      - target: %i
+        x-aws-protocol: http
+    deploy:
+      replicas: %i
+      resources:
+        limits:
+          cpus: '%f'
+          memory: %iM
+
+x-aws-logs_retention: 90
+
+x-aws-cloudformation:
+  Resources:
+    %sService:
+      Properties:
+        DeploymentConfiguration:
+          MaximumPercent: 100
+          MinimumHealthyPercent: 50
+%s    Default%iIngress:
+      Properties:
+        FromPort: 443
+        Description: %s:443/tcp on default network
+        ToPort: 443
+    %s%iListener:
+      Properties:
+        Certificates:
+          - CertificateArn: "%s"
+        Protocol: HTTPS
+        Port: 443
+    HttpToHttpsListener:
+      Properties:
+        DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Port: 443
+            Protocol: HTTPS
+            StatusCode: HTTP_301
+        LoadBalancerArn:
+          Ref: LoadBalancer
+        Port: 80
+        Protocol: HTTP
+      Type: AWS::ElasticLoadBalancingV2::Listener
+|} s.branch (* service *)
+   (command_colon s.command) (* command: something *)
+   s.port (* ports: - n where n is the container port the service is running on *)
+   s.replicas (* Number of instances to create *)
+   s.vcpu (* vcpu: is a factional value 0.5 => 512 out of 1024 cpu units *)
+   s.memory (* container RAM in MB *)
+   capitalized_branch
+   (storage_colon capitalized_branch s.storage) (* EC2 instance storage space - default 20GB *)
+   s.port s.branch (* Ingress description update and set overwrite port with 443 *)
+   capitalized_branch s.port s.certificate (* xxxTCPyyListerner set the SSL certificate to use *)
+  in
+  service
+
+(* Replace $IMAGE_HASH in the compose file with the fixed (hash) image id *)
+let replace_hash_var ~hash contents =
+  Re.Str.(global_replace (regexp_string "$IMAGE_HASH") hash contents)
+

--- a/src/dune
+++ b/src/dune
@@ -44,5 +44,5 @@
    str
    lwt
    lwt.unix)
- (modules index pipeline caddy logging mirage s build)
+ (modules index pipeline aws caddy logging mirage s build)
  (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -200,11 +200,11 @@ module Cluster = struct
     | `Compose contents ->
         let contents = Current.map (fun image ->
           Caddy.replace_hash_var ~hash:(D.Image.hash image) contents) image in
-        D.compose ~name ~contents ()
+        D.compose_cli ~name ~contents ~detach:true ()
     | `Compose_cli contents ->
         let contents = Current.map (fun hash ->
           Aws.replace_hash_var ~hash contents) repo_id in
-        D.compose_cli ~name ~contents ()
+        D.compose_cli ~name ~contents ~detach:false ()
 
   let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(additional_build_args=Current.return []) src =
     let src = Current.map (fun x -> [x]) src in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -122,6 +122,7 @@ module Cluster = struct
   module Opamocamlorg_docker = Current_docker.Make(struct let docker_context = Some "opam-3.ocaml.org" end)
   module V2ocamlorg_docker = Current_docker.Make(struct let docker_context = Some "v2.ocaml.org" end)
   module Ocamlorg_images = Current_docker.Make(struct let docker_context = Some "ci3.ocamllabs.io" end)
+  module Docker_aws = Current_docker.Make(struct let docker_context = Some "awsecs" end)
   module Deploycamlorg_docker = Current_docker.Default
 
   type build_info = {
@@ -148,6 +149,7 @@ module Cluster = struct
     | `Ocamlorg_images of string               (* Base Image builder @ images.ci.ocaml.org *)
     | `V3ocamlorg_cl of string                 (* OCaml website @ v3a.ocaml.org aka www.ocaml.org *)
     | `Stagingocamlorg_cl of string            (* Staging OCaml website @ staging.ocaml.org *)
+    | `Aws_ecs of Aws.t                        (* Amazon Web Services - Elastic Container Service *)
   ]
 
   type deploy_info = {
@@ -199,6 +201,10 @@ module Cluster = struct
         let contents = Current.map (fun image ->
           Caddy.replace_hash_var ~hash:(D.Image.hash image) contents) image in
         D.compose ~name ~contents ()
+    | `Compose_cli contents ->
+        let contents = Current.map (fun hash ->
+          Aws.replace_hash_var ~hash contents) repo_id in
+        D.compose_cli ~name ~contents ()
 
   let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(additional_build_args=Current.return []) src =
     let src = Current.map (fun x -> [x]) src in
@@ -242,6 +248,9 @@ module Cluster = struct
             | `Ocamlorg_images name -> pull_and_serve (module Ocamlorg_images) ~name `Service multi_hash
             | `V3ocamlorg_cl name -> pull_and_serve (module V3ocamlorg_docker) ~name `Service multi_hash
             | `Stagingocamlorg_cl name -> pull_and_serve (module Stagingocamlorg_docker) ~name `Service multi_hash
+            | `Aws_ecs project ->
+              let contents = Aws.compose project in
+              pull_and_serve (module Docker_aws) ~name:(project.name ^ "-" ^ project.branch) (`Compose_cli contents) multi_hash
           )
         |> Current.all
 end
@@ -368,9 +377,11 @@ let ocaml_org ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
     ocaml, "ocaml.org", [
       (* New V3 ocaml.org website. *)
-      docker "Dockerfile" ["main", "ocurrent/v3.ocaml.org-server:live", [`V3ocamlorg_cl "infra_www"]];
+      docker "Dockerfile" ["main", "ocurrent/v3.ocaml.org-server:live", [`V3ocamlorg_cl "infra_www";
+                                                                         `Aws_ecs {name = "v3a"; branch = "live"; vcpu = 0.5; memory = 2048; storage = None; replicas = 2; command = None; port = 8080; certificate = "arn:aws:acm:us-east-1:867081712685:certificate/24cde0e9-42c0-41ef-99d8-0fe8db462f36"}]];
       (* Staging branch for ocaml.org website. *)
-      docker "Dockerfile" ["staging", "ocurrent/v3.ocaml.org-server:staging", [`Stagingocamlorg_cl "infra_www"]]
+      docker "Dockerfile" ["staging", "ocurrent/v3.ocaml.org-server:staging", [`Stagingocamlorg_cl "infra_www";
+                                                                               `Aws_ecs {name = "v3a"; branch = "staging"; vcpu = 0.5; memory = 2048; storage = None; replicas = 1; command = None; port = 8080; certificate = "arn:aws:acm:us-east-1:867081712685:certificate/9647db34-004d-43d2-9102-accf6e09c63a"}]]
     ];
 
     ocaml, "v2.ocaml.org", [
@@ -413,8 +424,10 @@ let ocaml_org ?app ?notify:channel ?filter ~sched ~staging_auth () =
   let opam_repository_pipeline = filter_list filter [
     ocaml_opam, "opam2web", [
       docker_with_timeout (Duration.of_min 240)
-        "Dockerfile" [ "live", "ocurrent/opam.ocaml.org:live", [`Ocamlorg_opam "infra_opam_live"]
-                     ; "live-staging", "ocurrent/opam.ocaml.org:staging", [`Ocamlorg_opam "infra_opam_staging"]]
+        "Dockerfile" [ "live", "ocurrent/opam.ocaml.org:live", [`Ocamlorg_opam "infra_opam_live";
+                                                                `Aws_ecs {name = "opam3"; branch = "live"; vcpu = 0.25; memory = 512; storage = Some 50; replicas = 2; command = Some "--root /usr/share/caddy"; port = 80; certificate = "arn:aws:acm:us-east-1:867081712685:certificate/941be8db-4733-49c9-b634-43ff0537890c"}]
+                     ; "live-staging", "ocurrent/opam.ocaml.org:staging", [`Ocamlorg_opam "infra_opam_staging";
+                                                                           `Aws_ecs {name = "opam3"; branch = "staging"; vcpu = 0.25; memory = 512; storage = Some 50; replicas = 1; command = Some "--root /usr/share/caddy"; port = 80; certificate = "arn:aws:acm:us-east-1:867081712685:certificate/954e46c1-33fe-405d-ba4b-49ca189f050b"}]]
         ~options:(include_git |> build_kit)
         ~archs:[`Linux_arm64; `Linux_x86_64]
     ]


### PR DESCRIPTION
There are currently four pipelines: [www.ocaml.org](www.ocaml.org) live and staging and [opam-3.ocaml.org](opam-3.ocaml.org) live and staging.  The Docker containers for these services run on individually managed Amazon EC2 instances.

This PR adds pipelines, intended to replace the current deployments, with Amazon Fargate tasks deployed through Amazon Elastic Container Service (ECS).

ECS allows Docker containers to be deployed directly to either EC2 instances or to Amazon Fargate.  Fargate is a managed compute resource designed to run Docker containers.

A `docker-compose.yaml` is created using `Aws.compose` which describes the service including details of memory, CPU and storage.  This is deployed using `docker --context awsecs compose up`.  The Docker Compose CLI converts the `docker-compose.yaml` into an AWS Cloud Formation template (see `docker --context awsecs compose convert`) which includes the configuration of an elastic load balancer (ELB) and deploys it to ECS.

The service is updated with the same command used to deploy it.

For testing these services will be available via:
- v3a.ocamllabs.io
- staging.ocamllabs.io
- opam-3.ocamllabs.io
- opam-3-staging.ocamllabs.io

A new Docker secret will be needed to sign into AWS

```
services:
  deployer:
    image: ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org
    command: ...
    secrets:
    - source: aws_creds
      target: /root/.aws/credentials
      mode: 0400
```