### PR TITLE
Display build steps as clickable boxes

### DIFF
--- a/deployer.opam
+++ b/deployer.opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "lwt" {>= "5.6.1"}
   "cmdliner" {>= "1.1.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,6 @@
   fmt
   (lwt (>= 5.6.1))
   (cmdliner (>= 1.1.0))
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.13.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))))

--- a/src/build.ml
+++ b/src/build.ml
@@ -32,7 +32,7 @@ let notify ?channel ~web_ui ~service ~commit ~repo x =
   | Some channel ->
     let s =
       let+ state = Current.state x
-      and+ commit = commit in
+      and+ commit in
       let uri = Github.Api.Commit.uri commit in
       Fmt.str "@[<h>Deploy <%a|%a> as %s: <%s|%a>@]"
         Uri.pp uri Github.Api.Commit.pp_short commit
@@ -46,7 +46,7 @@ let notify ?channel ~web_ui ~service ~commit ~repo x =
 
 let label l x =
   Current.component "%s" l |>
-  let> x = x in
+  let> x in
   Current.Primitive.const x
 
 module Make(T : S.T) = struct

--- a/src/build.ml
+++ b/src/build.ml
@@ -50,8 +50,9 @@ let label l x =
   Current.Primitive.const x
 
 module Make(T : S.T) = struct
-  let status_of_build ~url b =
-    let+ state = Current.state b in
+  (* TODO Summarise build results. *)
+  let status_of_build ~url build =
+    let+ state = Current.state build in
     match state with
     | Ok _              -> Github.Api.CheckRunStatus.v ~url (`Completed `Success) ~summary:"Passed"
     | Error (`Active _) -> Github.Api.CheckRunStatus.v ~url `Queued
@@ -71,37 +72,32 @@ module Make(T : S.T) = struct
         |> Current.list_iter (module Github.Api.Commit) @@ fun commit ->
         let src = Current.map Github.Api.Commit.id commit in
         Current.all (
-            build_specs
-            |> List.map (fun (build_info, _) ->
-                   T.build ?additional_build_args build_info repo src
-                   |> Current.ignore_value)
+            List.map (fun (build_info, _) ->
+                T.build ?additional_build_args build_info repo src
+              ) build_specs
         )
         |> status_of_build ~url
         |> Github.Api.CheckRun.set_status commit "deployability"
       in
-      Current.collapse
-          ~key:"repo" ~value:collapse_value
-          ~input:refs pipeline 
+      Current.collapse ~key:"repo" ~value:collapse_value ~input:refs pipeline 
     and deployment =
       let root = label "deployments" root in
-         Current.with_context root @@ fun () ->
-         Current.all (
-           build_specs |> List.map (fun (build_info, deploys) ->
-               Current.all (
-                 deploys |> List.map (fun (branch, deploy_info) ->
-                    let service = T.name deploy_info in
-                    let commit, src = head_of ?github repo branch in
-                    let deploy = T.deploy build_info deploy_info ?additional_build_args src in
-                    match channel, commit with
-                    | Some channel, Some commit -> notify ~channel ~web_ui ~service ~commit ~repo:repo_name deploy
-                    | _ -> deploy
-                  )
+      Current.with_context root @@ fun () ->
+      Current.all (
+        build_specs |> List.map (fun (build_info, deploys) ->
+            Current.all (
+              deploys |> List.map (fun (branch, deploy_info) ->
+                 let service = T.name deploy_info in
+                 let commit, src = head_of ?github repo branch in
+                 let deploy = T.deploy build_info deploy_info ?additional_build_args src in
+                 match channel, commit with
+                 | Some channel, Some commit -> notify ~channel ~web_ui ~service ~commit ~repo:repo_name deploy
+                 | _ -> deploy
                )
-             )
-         )
-         |> Current.collapse
-              ~key:"repo" ~value:repo_name
-              ~input:root
+            )
+          )
+      )
+      |> Current.collapse ~key:"repo" ~value:repo_name ~input:root
     in
     Current.all (deployment :: Option.to_list builds)
 end

--- a/src/build.ml
+++ b/src/build.ml
@@ -73,7 +73,7 @@ module Make(T : S.T) = struct
         Current.all (
             build_specs
             |> List.map (fun (build_info, _) ->
-                   T.build ?additional_build_args build_info src
+                   T.build ?additional_build_args build_info repo src
                    |> Current.ignore_value)
         )
         |> status_of_build ~url

--- a/src/index.ml
+++ b/src/index.ml
@@ -86,6 +86,6 @@ let record ~repo ~hash jobs =
   let _ : [`Empty] Job_map.t = Job_map.merge merge previous jobs in
   ()
 
-let get_job_ids  ~owner ~name ~hash =
+let get_job_ids ~owner ~name ~hash =
   let t = Lazy.force db in
   get_job_ids_with_variant t ~owner ~name ~hash |> List.filter_map snd

--- a/src/mirage.ml
+++ b/src/mirage.ml
@@ -75,7 +75,7 @@ module Deploy = Current_cache.Output(Op)
 module Make(Docker : Current_docker.S.DOCKER) = struct
   let deploy ~name ~ssh_host image =
     Current.component "deploy %s" name |>
-    let> image = image in
+    let> image in
     let docker_context = Docker.docker_context in
     Deploy.set Op.No_context { Op.Key.name; ssh_host; docker_context } (Docker.Image.hash image |> Raw.Image.of_hash)
 end

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -217,7 +217,7 @@ module Cluster = struct
   let pull_and_serve (module D : Current_docker.S.DOCKER) ~name op repo_id =
     let image =
       Current.component "pull" |>
-      let> repo_id = repo_id in
+      let> repo_id in
       Current_docker.Raw.pull repo_id
       ~docker_context:D.docker_context
       ~schedule:no_schedule
@@ -239,6 +239,7 @@ module Cluster = struct
   let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(additional_build_args=Current.return []) src =
     let src = Current.map (fun x -> [x]) src in
     let target_label = Cluster_api.Docker.Image_id.repo hub_id |> String.map (function '/' | ':' -> '-' | c -> c) in
+    (* TODO Clean this up like build. *)
     Current.component "HEADs" |>
     let** additional_build_args = additional_build_args in
     let options = { options with build_args = additional_build_args @ options.build_args } in

--- a/src/s.ml
+++ b/src/s.ml
@@ -5,6 +5,7 @@ module type T = sig
   val build :
     build_info ->
     ?additional_build_args:string list Current.t ->
+    Current_github.Repo_id.t ->
     Current_git.Commit_id.t Current.t -> unit Current.t
 
   val name : deploy_info -> string

--- a/src/s.ml
+++ b/src/s.ml
@@ -5,7 +5,6 @@ module type T = sig
   val build :
     build_info ->
     ?additional_build_args:string list Current.t ->
-    Current_github.Repo_id.t ->
     Current_git.Commit_id.t Current.t -> unit Current.t
 
   val name : deploy_info -> string


### PR DESCRIPTION
Before 

<img width="1146" alt="Screen Shot 2022-08-04 at 09 49 33" src="https://user-images.githubusercontent.com/170937/182732045-cff8a81a-deca-4223-aa48-9918f1fd7b8d.png">

After
<img width="1175" alt="Screen Shot 2022-08-04 at 09 50 30" src="https://user-images.githubusercontent.com/170937/182732003-6b9c8a70-9827-4e62-a4d1-536553e1fdcb.png">

The main change is 07406b636cc66a56f5aede447e86f02bde8aa0dd and should be sufficient.
The second change d6982c88dfb57a2f5132b89b6c07a62c76651011 is an attempt to get rid of the 2 build boxes that are actually a single build.

