### PR TITLE
Add deployer for ocurrent/solver-service

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -327,6 +327,9 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
     ocurrent, "mirage-ci", [
         docker "Dockerfile" ["live", "ocurrent/mirage-ci:live", [`Cimirage "infra_mirage-ci"]]
         ~options:(include_git |> build_kit)
+      ];
+    ocurrent, "solver-service", [
+      docker "Dockerfile" ["live", "ocurrent/solver-service:live", [`Ci4 "infra_solver-service"]];
     ]
   ]
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -329,7 +329,8 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
         ~options:(include_git |> build_kit)
       ];
     ocurrent, "solver-service", [
-      docker "Dockerfile" ["live", "ocurrent/solver-service:live", [`Ci4 "infra_solver-service"]];
+      docker "Dockerfile" ["live", "ocurrent/solver-service:live", [`Ci4 "infra_solver-service"]]
+        ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64]
     ]
   ]
 


### PR DESCRIPTION
[OCaml-multicore-CI](https://github.com/ocurrent/ocaml-multicore-ci) and [OCaml-CI](https://github.com/ocurrent/ocaml-ci) will move to use [solver-service](https://github.com/ocurrent/solver-service).