### PR TITLE
Add monitoring flags for mirage.io website

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -446,8 +446,8 @@ let toxis ?app ?notify:channel () =
   let build (org, name, builds) = Build_unikernel.repo ?channel ~web_ui ~org ~name builds in
   Current.all @@ List.map build [
     mirage, "mirage-www", [
-      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true"] ["master", "www"];
-      unikernel "Dockerfile" ~target:"xen" ["EXTRA_FLAGS=--tls=true"] [];     (* (no deployments) *)
-      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true"] ["next", "next"];
+      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["master", "www"];
+      unikernel "Dockerfile" ~target:"xen" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] [];     (* (no deployments) *)
+      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["next", "next"];
     ];
   ]


### PR DESCRIPTION
We're adding monitoring to mirage.io, it's introducing additional configure-time flags: https://github.com/mirage/mirage-www/pull/767