### PR TITLE
Remove solver service container deployment on ci4

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -335,7 +335,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
         ~options:(include_git |> build_kit)
       ];
     ocurrent, "solver-service", [
-      docker "Dockerfile" ["live", "ocurrent/solver-service:live", [`Ci4 "infra_solver-service"]]
+      docker "Dockerfile" ["live", "ocurrent/solver-service:live", []]
         ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64]
     ]
   ]


### PR DESCRIPTION
The solver service will now be deployed natively rather than through a Docker container matching the deployment of an ocluster worker.