### PR TITLE
Build clarke images

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -367,6 +367,8 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
         ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       docker "Dockerfile.worker" ["live-worker",    "ocurrent/ocluster-worker:live", []]
         ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64] ~options:include_git;
+      docker "Dockerfile"        ["live",   "ocurrent/clarke:live", []] 
+        ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64] ~options:include_git;
     ];
     ocurrent, "opam-repo-ci", [
       docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Dev1 "opam-repo-ci_opam-repo-ci"]];


### PR DESCRIPTION
Adds clarke to the images to be built and pushed to docker. The power monitors will probably be installed and updated like ocluster-worker services rather than from the deployer.