### PR TITLE
Deployer for `tarides.com`. Initial version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
+_opam
 .merlin
 *.install
 /var/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ocurrent"]
 	path = ocurrent
 	url = https://github.com/ocurrent/ocurrent.git
-	branch = master
+	branch = feature/git-private
 [submodule "ocluster"]
 	path = ocluster
 	url = https://github.com/ocurrent/ocluster.git

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -139,6 +139,7 @@ module Docker_context = struct
             D.build ~dockerfile
                 ~label:target
                 ~pull:true
+                ~buildx:true
                 ~timeout
                 (`Git src)
         in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -111,6 +111,26 @@ end
 module Build_unikernel = Build.Make(Packet_unikernel)
 
 module Docker_context = struct
+(** The Docker_context module relies on [docker --context url cmd] to execute
+    the request on the remote machine. It requires the server to preload [ssh]
+    keys from the remote server.
+
+    +----------------+                          +---------------------------+
+    | Server         |                          | Remote machine            |
+    | +------------+ |                          | +---------------------+   |
+    | | OCurrent   | |                +---------->| docker buildx build |   |
+    | | +--------+ | |          1     |         | +---------------------+   |
+    | | | Docker |--------------------+         | +-----------------------+ |
+    | | +--------+ | |                    +------>| docker service update | |
+    | +-----|------+ |               +----+     | +------------------------+|
+    +-------|--------+        2      |          +---------------------------+
+            +------------------------+
+
+    The build part (1) executes [docker buildx build] to generate the image on the
+    remote machine. The deploy port use [docker swarm] to deploy services by
+    executing [docker service update]. This ensures the service are up-to-date with
+    the newly build image. *)
+
     module Taridescom = Current_docker.Make(struct let docker_context = Some "staging.tarides.com" end)
     
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -474,7 +474,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
   let remote_docker = List.map build_with_context @@ filter_list filter [
     tarides, "tarides.com", [
-      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "taridescom") ~target:"tarides/tarides.com" ~args:["--secret", "id=production,src=/run/secrets/tarides-production"] ["live"]
+      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "infra_taridescom") ~target:"tarides/tarides.com" ~args:["--secret", "id=production,src=/run/secrets/tarides-production"] ["live"]
     ]
   ]
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -474,7 +474,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
   let remote_docker = List.map build_with_context @@ filter_list filter [
     tarides, "tarides.com", [
-      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "taridescom") ~target:"tarides/tarides.com" ~args:["--secret", "id=production_env,src=/run/secrets/tarides-production"] ["live"]
+      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "taridescom") ~target:"tarides/tarides.com" ~args:["--secret", "id=production,src=/run/secrets/tarides-production"] ["live"]
     ]
   ]
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -134,13 +134,17 @@ module Docker_context = struct
     | `Taridescom service -> service
 
 
-    let generate (module D : Current_docker.S.DOCKER) ~dockerfile ~target ~args:_ src =
+    let generate (module D : Current_docker.S.DOCKER) ~dockerfile ~target ~args src =
+        let build_args =
+            List.map (fun (flag, args) -> flag ^ " " ^ args) args
+        in
         let+ image =
             D.build ~dockerfile
                 ~label:target
                 ~pull:true
                 ~buildx:true
                 ~timeout
+                ~build_args
                 (`Git src)
         in
         D.Image.hash image
@@ -469,7 +473,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
   let remote_docker = List.map build_with_context @@ filter_list filter [
     tarides, "tarides.com", [
-      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "taridescom") ~target:"tarides/tarides.com" ~args:[] ["live"]
+      docker_with_context "Dockerfile" ?api:(Build.api tarides) ~service:(`Taridescom "taridescom") ~target:"tarides/tarides.com" ~args:["--secret", "id=production_env,src=/run/secrets/tarides-production"] ["live"]
     ]
   ]
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -136,7 +136,8 @@ module Docker_context = struct
 
     let generate (module D : Current_docker.S.DOCKER) ~dockerfile ~target ~args src =
         let build_args =
-            List.map (fun (flag, args) -> flag ^ " " ^ args) args
+          List.map (fun (flag, args) -> [flag ; args]) args
+          |> List.flatten
         in
         let+ image =
             D.build ~dockerfile

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -406,7 +406,9 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
   let ocaml_bench = Build.org ?app ~account:"ocaml-bench" 19839896 in
   let tarides = Build.org ?app ~account:"tarides" 21197588 in
 
-  let build_with_context (org, name, builds) = Docker_context_build.repo ?channel ~web_ui ~org ~name builds (* XXX: verify with the unikernel version. *) in
+  let build_with_context (org, name, builds) =
+    Docker_context_build.repo ?channel ~web_ui ~org ~name builds (* XXX: verify with the unikernel version. *)
+  in
   let docker_with_context dockerfile ?api ~service ~target ~args services =
     let token = Option.map Github.Api.get_token api in
     let build_info = { token ; Docker_context.service ; target ; dockerfile ; args } in
@@ -479,7 +481,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
   ]
 
   in
-  Current.all (List.append cluster remote_docker)
+  Current.all (cluster @ remote_docker)
 
 
 (* This is a list of GitHub repositories to monitor.

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -408,7 +408,7 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
 
   let build_with_context (org, name, builds) = Docker_context_build.repo ?channel ~web_ui ~org ~name builds (* XXX: verify with the unikernel version. *) in
   let docker_with_context dockerfile ?api ~service ~target ~args services =
-    let token = Option.map (fun api -> Github.Api.get_token api) api in
+    let token = Option.map Github.Api.get_token api in
     let build_info = { token ; Docker_context.service ; target ; dockerfile ; args } in
     let deploys =
       services 


### PR DESCRIPTION
This version introduces a minimal version to deploy tarides.com. The secret will be mounted later once we are sure it can deploy the website.

The idea is to use `docker build build` to build the image in a distant context and then update the service with the newly built image. The following schema describes the behaviour:

![schema](https://user-images.githubusercontent.com/22150236/228580710-e4c7eeea-1a7d-408e-a272-37f6308bea7d.jpg)

EDIT: it is deployed on `live-ci3` to track deployment issues. You can see it here: https://deploy.ci.dev/?repo=tarides/tarides.com&. 

However, @mtelvers pointed out that we don't support private GitHub repositories. It gives us two choices: putting `tarides/tarides.com` as public or update `current_github` to support private repositories. The first one is the easier.