### PR TITLE
Added docker-buildx-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ FROM debian:11
 RUN apt-get update && apt-get install libffi-dev libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase rsync awscli -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce docker-ce-cli docker-compose-plugin -y --no-install-recommends
+RUN apt-get update && apt-get install docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin -y --no-install-recommends
 RUN curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocurrent-deployer"]


### PR DESCRIPTION
From Docker Engine version 23.0.0, Buildx is distributed in a separate package: `docker-buildx-plugin`. In earlier versions, Buildx was included in the `docker-ce-cli`.