### PR TITLE
Use docker login on pull

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -220,6 +220,7 @@ module Cluster = struct
       Current.component "pull" |>
       let> repo_id in
       Current_docker.Raw.pull repo_id
+      ?auth
       ~docker_context:D.docker_context
       ~schedule:no_schedule
       |> Current.Primitive.map_result (Result.map (fun raw_image ->


### PR DESCRIPTION
This PR supports `docker login` in `docker pull`.  The goal is to overcome the rate limit by using an authenticated user.

Fixes #172 