### PR TITLE
Enable ARM64 builds for OCaml-CI and Opam-Repo-CI

### DIFF
--- a/create-config.sh
+++ b/create-config.sh
@@ -9,14 +9,13 @@ docker context create "deploy.ci.ocaml.org" --description "OCaml - deploy.ci.oca
 docker context create "dev1.ocamllabs.io" --description "OCaml - opam-repo-ci" --docker "host=ssh://root@dev1.ocamllabs.io"
 docker context create "docs.ci.ocaml.org" --description "OCaml - docs.ci.ocaml.org" --docker "host=ssh://root@docs.ci.ocaml.org"
 docker context create "staging.docs.ci.ocaml.org" --description "Staging for docs.ci.ocaml.org" --docker "host=ssh://root@staging.docs.ci.ocaml.org"
-docker context create "opam-3.ocaml.org" --description "OPAM - opam-3.ocaml.org" --docker "host=ssh://root@opam-3.ocaml.org"
 docker context create "opam-4.ocaml.org" --description "OPAM - opam-4.ocaml.org" --docker "host=ssh://root@opam-4.ocaml.org"
 docker context create "opam-5.ocaml.org" --description "OPAM - opam-5.ocaml.org" --docker "host=ssh://root@opam-5.ocaml.org"
 docker context create "v2.ocaml.org" --description "OCaml - v2.ocaml.org" --docker "host=ssh://root@v2.ocaml.org"
 docker context create "v3b.ocaml.org" --description "OCaml - www.ocaml.org" --docker "host=ssh://root@v3b.ocaml.org"
 docker context create "v3c.ocaml.org" --description "OCaml - staging.ocaml.org" --docker "host=ssh://root@v3c.ocaml.org"
 docker context create "watch.ocaml.org" --description "OCaml - watch.ocaml.org" --docker "host=ssh://root@watch.ocaml.org"
-docker context create "staging.tarides.com" --description "Tarides - staging.tarides.com" --docker "host=ssh://root@staging.tarides.com"
+docker context create "opam-repo-ci.sw.ocaml.org" --description "Tarides/OCaml - Opam Repo CI / OCaml CI" --docker "host=ssh://root@opam-repo-ci.sw.ocaml.org"
 
 # Create AWS context
 mkdir ~/.aws
@@ -35,14 +34,13 @@ for host in \
   dev1.ocamllabs.io \
   docs.ci.ocaml.org \
   staging.docs.ci.ocaml.org \
-  opam-3.ocaml.org \
   opam-4.ocaml.org \
   opam-5.ocaml.org \
   v2.ocaml.org \
   v3b.ocaml.org \
   v3c.ocaml.org \
   watch.ocaml.org \
-  staging.tarides.com \
+  opam-repo-ci.sw.ocaml.org \
   147.75.84.37 ; do
   ssh-keyscan -H -t ecdsa-sha2-nistp256 $host >> ~/.ssh/known_hosts
 done

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -116,7 +116,7 @@ module Cluster = struct
   module Ci4_docker = Current_docker.Make(struct let docker_context = Some "ci4.ocamllabs.io" end)
   module Docs_docker = Current_docker.Make(struct let docker_context = Some "docs.ci.ocaml.org" end)
   module Staging_docs_docker = Current_docker.Make(struct let docker_context = Some "staging.docs.ci.ocaml.org" end)
-  module Toxis_docker = Current_docker.Make(struct let docker_context = Some "ci.ocamllabs.io" end)
+  module Ci_docker = Current_docker.Make(struct let docker_context = Some "opam-repo-ci.sw.ocaml.org" end)
   module Watch_docker = Current_docker.Make(struct let docker_context = Some "watch.ocaml.org" end)
   module Ocamlorg_docker = Current_docker.Make(struct let docker_context = Some "ocaml-www1" end)
   module Cimirage_docker = Current_docker.Make(struct let docker_context = Some "ci.mirage.io" end)
@@ -124,7 +124,6 @@ module Cluster = struct
   module Opam5_docker = Current_docker.Make(struct let docker_context = Some "opam-5.ocaml.org" end)
   module V2ocamlorg_docker = Current_docker.Make(struct let docker_context = Some "v2.ocaml.org" end)
   module Ocamlorg_images = Current_docker.Make(struct let docker_context = Some "ci3.ocamllabs.io" end)
-  module Dev1_docker = Current_docker.Make(struct let docker_context = Some "dev1.ocamllabs.io" end)
   module Docker_aws = Current_docker.Make(struct let docker_context = Some "awsecs" end)
   module V3b_docker = Current_docker.Make(struct let docker_context = Some "v3b.ocaml.org" end)
   module V3c_docker = Current_docker.Make(struct let docker_context = Some "v3c.ocaml.org" end)
@@ -139,10 +138,9 @@ module Cluster = struct
 
   type service = [
     (* Services on deploy.ci3.ocamllabs.io *)
-    | `Toxis of string
+    | `Ci of string
     | `Ci3 of string
     | `Ci4 of string
-    | `Dev1 of string
     | `Docs of string
     | `Staging_docs of string
     | `Cimirage of string
@@ -271,10 +269,9 @@ module Cluster = struct
             (* ci3.ocamllabs.io *)
             | `Ci3 name -> pull_and_serve (module Ci3_docker) ~name `Service multi_hash
             | `Ci4 name -> pull_and_serve (module Ci4_docker) ~name `Service multi_hash
-            | `Dev1 name -> pull_and_serve (module Dev1_docker) ~name `Service multi_hash
             | `Docs name -> pull_and_serve (module Docs_docker) ~name `Service multi_hash
             | `Staging_docs name -> pull_and_serve (module Staging_docs_docker) ~name `Service multi_hash
-            | `Toxis name -> pull_and_serve (module Toxis_docker) ~name `Service multi_hash
+            | `Ci name -> pull_and_serve (module Ci_docker) ~name `Service multi_hash
             | `Cimirage name -> pull_and_serve (module Cimirage_docker) ~name `Service multi_hash
 
             (* ocaml.org *)
@@ -351,10 +348,13 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
       docker "Dockerfile"     ["live-ci3",   "ocurrent/ci.ocamllabs.io-deployer:live-ci3",   [`Ci3 "deployer_deployer"]];
     ];
     ocurrent, "ocaml-ci", [
-      docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Toxis "ocaml-ci_ci"]];
-      docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Toxis "ocaml-ci_gitlab"]];
-      docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Toxis "ocaml-ci_web"];
-                               "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Toxis "test-www"]];
+      docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Ci "ocaml-ci_ci"]]
+        ~archs:[`Linux_arm64];
+      docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Ci "ocaml-ci_gitlab"]]
+        ~archs:[`Linux_arm64];
+      docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Ci "ocaml-ci_web"];
+                               "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Ci "test-www"]]
+        ~archs:[`Linux_arm64];
     ];
     ocurrent, "ocluster", [
       docker "Dockerfile"        ["live-scheduler", "ocurrent/ocluster-scheduler:live", []]
@@ -369,8 +369,10 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
     ocurrent, "opam-repo-ci", [
-      docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Toxis "opam-repo-ci_opam-repo-ci"]];
-      docker "Dockerfile.web" ["live-web", "ocurrent/opam-repo-ci-web:live", [`Toxis "opam-repo-ci_opam-repo-ci-web"]];
+      docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Ci "opam-repo-ci_opam-repo-ci"]]
+        ~archs:[`Linux_arm64];
+      docker "Dockerfile.web" ["live-web", "ocurrent/opam-repo-ci-web:live", [`Ci "opam-repo-ci_opam-repo-ci-web"]]
+        ~archs:[`Linux_arm64];
     ];
     ocurrent, "ocaml-multicore-ci", [
       docker "Dockerfile"     ["live", "ocurrent/multicore-ci:live", [`Ci4 "infra_multicore-ci"]];

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -349,12 +349,12 @@ let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
     ];
     ocurrent, "ocaml-ci", [
       docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Ci "ocaml-ci_ci"]]
-        ~archs:[`Linux_arm64];
+        ~archs:[`Linux_x86_64; `Linux_arm64];
       docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Ci "ocaml-ci_gitlab"]]
-        ~archs:[`Linux_arm64];
+        ~archs:[`Linux_x86_64; `Linux_arm64];
       docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Ci "ocaml-ci_web"];
                                "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Ci "test-www"]]
-        ~archs:[`Linux_arm64];
+        ~archs:[`Linux_x86_64; `Linux_arm64];
     ];
     ocurrent, "ocluster", [
       docker "Dockerfile"        ["live-scheduler", "ocurrent/ocluster-scheduler:live", []]


### PR DESCRIPTION
Enable ARM64 builds for OCaml-CI and Opam-Repo-CI ref https://github.com/ocaml/infrastructure/issues/51.