### PR TITLE
Separate services from pipeline

### DIFF
--- a/src/local.ml
+++ b/src/local.ml
@@ -21,9 +21,9 @@ let main () config mode app sched staging_password_file repo flavour =
   let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
   let staging_auth = staging_password_file |> Option.map (fun path -> staging_user, read_first_line path) in
   let engine = match flavour with
-    | `Tarides -> Current.Engine.create ~config (Pipeline.tarides ?app ~sched ~staging_auth ?filter)
-    | `OCaml -> Current.Engine.create ~config (Pipeline.ocaml_org ?app ~sched ~staging_auth ?filter)
-    | `Mirage -> Current.Engine.create ~config (Pipeline.mirage ?app ~sched ~staging_auth)
+    | `Tarides -> Current.Engine.create ~config (Pipeline.Tarides.v ?app ~sched ~staging_auth ?filter)
+    | `OCaml -> Current.Engine.create ~config (Pipeline.Ocaml_org.v ?app ~sched ~staging_auth ?filter)
+    | `Mirage -> Current.Engine.create ~config (Pipeline.Mirage.v ?app ~sched ~staging_auth)
   in
   let webhook_secret = Option.value ~default:webhook_secret @@ Option.map Current_github.App.webhook_secret app in
   let has_role = Current_web.Site.allow_all in

--- a/src/main.ml
+++ b/src/main.ml
@@ -89,13 +89,13 @@ let main () config mode app slack auth staging_password_file flavour =
   let engine = match flavour with
     | Tarides sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.tarides ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Tarides.v ~app ~notify:channel ~sched ~staging_auth)
     | OCaml sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.ocaml_org ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Ocaml_org.v ~app ~notify:channel ~sched ~staging_auth)
     | Mirage sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.mirage ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Mirage.v ~app ~notify:channel ~sched ~staging_auth)
   in
   let authn = Option.map Current_github.Auth.make_login_uri auth in
   let webhook_secret = Current_github.App.webhook_secret app in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -244,10 +244,10 @@ module Ocaml_org = struct
       Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
     in
     let pipelines = filter_list filter @@ services ?app ~sched ~staging_auth () in
-
     let opam_repository_pipelines, additional_build_args =
-      opam_repository ?app ()
-      |> (fun (pipelines, args) -> filter_list filter @@ pipelines, args)
+      let pipelines, args = opam_repository ?app () in
+      let filtered_pipelines = filter_list filter @@ pipelines in
+      filtered_pipelines, args
     in
     Current.all (
       (List.map (build_for_registry ~additional_build_args) opam_repository_pipelines)

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -57,133 +57,123 @@ let include_git = { Cluster_api.Docker.Spec.defaults with include_git = true }
 
 let build_kit (v : Cluster_api.Docker.Spec.options) = { v with buildkit = true }
 
-(* This is a list of GitHub repositories to monitor.
-   For each one, it lists the builds that are made from that repository.
-   For each build, it says which which branch gives the desired live version of
-   the service, and where to deploy it. *)
-let tarides ?app ?notify:channel ?filter ~sched ~staging_auth () =
-  (* [web_ui collapse_value] is a URL back to the deployment service, for links
-     in status messages. *)
-  let web_ui =
-    let base = Uri.of_string "https://deploy.ci.dev/" in
-    fun repo -> Uri.with_query' base ["repo", repo] in
+module Tarides = struct
+  let base_url = Uri.of_string "https://deploy.ci.dev/"
 
-  (* GitHub organisations to monitor. *)
-  let ocurrent = Build.org ?app ~account:"ocurrent" 12497518 in
-  let ocaml_bench = Build.org ?app ~account:"ocaml-bench" 19839896 in
-
-  let build (org, name, builds) = Cluster_build.repo ?channel ~web_ui ~org ~name builds in
-  let docker ?archs =
-    let timeout = match archs with
-      | Some archs when List.mem `Linux_riscv64 archs -> Int64.mul Build.timeout 2L
-      | _ -> Build.timeout
+  (* This is a list of GitHub repositories to monitor.
+    For each one, it lists the builds that are made from that repository.
+    For each build, it says which which branch gives the desired live version of
+    the service, and where to deploy it. *)
+  let services ?app ~sched ~staging_auth () =
+    (* GitHub organisations to monitor. *)
+    let ocurrent = Build.org ?app ~account:"ocurrent" 12497518 in
+    let ocaml_bench = Build.org ?app ~account:"ocaml-bench" 19839896 in
+    let docker ?archs =
+      let timeout = match archs with
+        | Some archs when List.mem `Linux_riscv64 archs -> Int64.mul Build.timeout 2L
+        | _ -> Build.timeout
+      in
+      docker ?archs ~sched:(Current_ocluster.v ~timeout ?push_auth:staging_auth sched)
     in
-    docker ?archs ~sched:(Current_ocluster.v ~timeout ?push_auth:staging_auth sched)
-  in
-
-  Current.all @@ List.map build @@ filter_list filter [
-    ocurrent, "ocurrent-deployer", [
-      docker "Dockerfile"     ["live-ci3",   "ocurrent/ci.ocamllabs.io-deployer:live-ci3",   [`Ci3 "deployer_deployer"]];
-    ];
-    ocurrent, "ocaml-ci", [
-      docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Ci "ocaml-ci_ci"]]
-        ~archs:[`Linux_x86_64; `Linux_arm64];
-      docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Ci "ocaml-ci_gitlab"]]
-        ~archs:[`Linux_x86_64; `Linux_arm64];
-      docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Ci "ocaml-ci_web"];
-                               "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Ci "test-www"]]
-        ~archs:[`Linux_x86_64; `Linux_arm64];
-    ];
-    ocurrent, "ocluster", [
-      docker "Dockerfile"        ["live-scheduler", "ocurrent/ocluster-scheduler:live", []]
-        ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
-      docker "Dockerfile.worker" ["live-worker",    "ocurrent/ocluster-worker:live", []]
-        ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64] ~options:(include_git |> fun v ->  { v with build_args =  ["--ulimit stack=1000000000:1000000000"]});
-      docker "Dockerfile.worker.alpine" ["live-worker",    "ocurrent/ocluster-worker:alpine", []]
-        ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
+    [
+      ocurrent, "ocurrent-deployer", [
+        docker "Dockerfile"     ["live-ci3",   "ocurrent/ci.ocamllabs.io-deployer:live-ci3",   [`Ci3 "deployer_deployer"]];
       ];
-    ocurrent, "clarke", [
+      ocurrent, "ocaml-ci", [
+        docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Ci "ocaml-ci_ci"]]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+        docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Ci "ocaml-ci_gitlab"]]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+        docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Ci "ocaml-ci_web"];
+                                "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Ci "test-www"]]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+      ];
+      ocurrent, "ocluster", [
+        docker "Dockerfile"        ["live-scheduler", "ocurrent/ocluster-scheduler:live", []]
+          ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
+        docker "Dockerfile.worker" ["live-worker",    "ocurrent/ocluster-worker:live", []]
+          ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64] ~options:(include_git |> fun v ->  { v with build_args =  ["--ulimit stack=1000000000:1000000000"]});
+        docker "Dockerfile.worker.alpine" ["live-worker",    "ocurrent/ocluster-worker:alpine", []]
+          ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
+      ];
+      ocurrent, "clarke", [
         docker "Dockerfile" ["live",   "ocurrent/clarke:live", []]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
-    ocurrent, "opam-repo-ci", [
-      docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Opamrepo "opam-repo-ci_opam-repo-ci"]]
-        ~archs:[`Linux_x86_64; `Linux_arm64];
-      docker "Dockerfile.web" ["live-web", "ocurrent/opam-repo-ci-web:live", [`Opamrepo "opam-repo-ci_opam-repo-ci-web"]]
-        ~archs:[`Linux_x86_64; `Linux_arm64];
-    ];
-    ocurrent, "opam-health-check", [
-      docker "Dockerfile" ["live", "ocurrent/opam-health-check:live", [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"]];
-    ];
-    ocurrent, "ocaml-multicore-ci", [
-      docker "Dockerfile"     ["live", "ocurrent/multicore-ci:live", [`Ci4 "infra_multicore-ci"]];
-      docker "Dockerfile.web" ["live-web", "ocurrent/multicore-ci-web:live", [`Ci4 "infra_multicore-ci-web"]];
-    ];
-    ocurrent, "ocurrent.org", [
-      docker "Dockerfile"     ["live-engine", "ocurrent/ocurrent.org:live-engine", [`Ci3 "ocurrent_org_watcher"]];
-    ];
-    ocaml_bench, "sandmark-nightly", [
-      docker "Dockerfile" ["main", "ocurrent/sandmark-nightly:live", [`Ci3 "sandmark_sandmark"]]
-      ~options:include_git;
-    ];
-    ocurrent, "solver-service", [
-      docker "Dockerfile" ["live", "ocurrent/solver-service:live", []]
-        ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
-      docker "Dockerfile" ["staging", "ocurrent/solver-service:staging", []]
-        ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
-    ];
-    ocurrent, "multicoretests-ci", [
-      docker "Dockerfile" ["live", "ocurrent/multicoretests-ci:live", [`Ci4 "infra_multicoretests-ci"]];
-    ];
-  ]
+      ocurrent, "opam-repo-ci", [
+        docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Opamrepo "opam-repo-ci_opam-repo-ci"]]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+        docker "Dockerfile.web" ["live-web", "ocurrent/opam-repo-ci-web:live", [`Opamrepo "opam-repo-ci_opam-repo-ci-web"]]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+      ];
+      ocurrent, "opam-health-check", [
+        docker "Dockerfile" ["live", "ocurrent/opam-health-check:live", [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"]];
+      ];
+      ocurrent, "ocaml-multicore-ci", [
+        docker "Dockerfile"     ["live", "ocurrent/multicore-ci:live", [`Ci4 "infra_multicore-ci"]];
+        docker "Dockerfile.web" ["live-web", "ocurrent/multicore-ci-web:live", [`Ci4 "infra_multicore-ci-web"]];
+      ];
+      ocurrent, "ocurrent.org", [
+        docker "Dockerfile"     ["live-engine", "ocurrent/ocurrent.org:live-engine", [`Ci3 "ocurrent_org_watcher"]];
+      ];
+      ocaml_bench, "sandmark-nightly", [
+        docker "Dockerfile" ["main", "ocurrent/sandmark-nightly:live", [`Ci3 "sandmark_sandmark"]]
+        ~options:include_git;
+      ];
+      ocurrent, "solver-service", [
+        docker "Dockerfile" ["live", "ocurrent/solver-service:live", []]
+          ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
+        docker "Dockerfile" ["staging", "ocurrent/solver-service:staging", []]
+          ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
+      ];
+      ocurrent, "multicoretests-ci", [
+        docker "Dockerfile" ["live", "ocurrent/multicoretests-ci:live", [`Ci4 "infra_multicoretests-ci"]];
+      ];
+    ]
 
-(* This is a list of GitHub repositories to monitor.
-   For each one, it lists the builds that are made from that repository.
-   For each build, it says which which branch gives the desired live version of
-   the service, and where to deploy it. *)
-let ocaml_org ?app ?notify:channel ?filter ~sched ~staging_auth () =
-  (* [web_ui collapse_value] is a URL back to the deployment service, for links
-     in status messages. *)
-  let web_ui =
-    let base = Uri.of_string "https://deploy.ci.ocaml.org" in
-    fun repo -> Uri.with_query' base ["repo", repo] in
+  let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
+    (* [web_ui collapse_value] is a URL back to the deployment service, for links
+      in status messages. *)
+    let web_ui repo = Uri.with_query' base_url ["repo", repo] in
+    let build (org, name, builds) =
+      Cluster_build.repo ?channel ~web_ui ~org ~name builds
+    in
+    Current.all @@ List.map build @@ filter_list filter @@
+      services ?app ~sched ~staging_auth ()
+end
 
-  (* GitHub organisations to monitor. *)
-  let ocurrent = Build.org ?app ~account:"ocurrent" 23342906 in
-  let ocaml = Build.org ?app ~account:"ocaml" 23711648 in
-  let ocaml_opam = Build.org ?app ~account:"ocaml-opam" 23690708 in
+module Ocaml_org = struct
+  let base_url = Uri.of_string "https://deploy.ci.ocaml.org"
 
-  let build ?additional_build_args (org, name, builds) =
-    Cluster_build.repo ?channel ?additional_build_args ~web_ui ~org ~name builds in
-
-  let build_for_registry ?additional_build_args (org, name, builds) =
-    Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds in
-
-  let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
-  let docker = docker ~sched in
-  let pipelines = filter_list filter [
-    ocurrent, "ocurrent-deployer", [
-      docker "Dockerfile"     ["live-ocaml-org", "ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org", [`Ocamlorg_deployer "infra_deployer"]];
-    ];
-    
-    ocaml, "ocaml.org", [
-      (* New V3 ocaml.org website. *)
-      docker "Dockerfile" ["main", "ocurrent/v3.ocaml.org-server:live", [`OCamlorg_v3b "infra_www"]] ~options:include_git;
-      (* Staging branch for ocaml.org website. *)
-      docker "Dockerfile" ["staging", "ocurrent/v3.ocaml.org-server:staging", [`OCamlorg_v3c "infra_www"]] ~options:include_git
-    ];
-
-    ocaml, "v2.ocaml.org", [
-      (* Backup of existing ocaml.org website. *)
-      docker "Dockerfile.deploy"  ["master", "ocurrent/v2.ocaml.org:live", [`OCamlorg_v2 ["v2.ocaml.org", None]]] ~options:include_git;
-    ];
-
-    ocurrent, "docker-base-images", [
+  (* This is a list of GitHub repositories to monitor.
+    For each one, it lists the builds that are made from that repository.
+    For each build, it says which which branch gives the desired live version of
+    the service, and where to deploy it. *)
+  let services ?app ~sched ~staging_auth () =
+    (* GitHub organisations to monitor. *)
+    let ocurrent = Build.org ?app ~account:"ocurrent" 23342906 in
+    let ocaml = Build.org ?app ~account:"ocaml" 23711648 in
+    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
+    let docker = docker ~sched in
+    [
+      ocurrent, "ocurrent-deployer", [
+        docker "Dockerfile"     ["live-ocaml-org", "ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org", [`Ocamlorg_deployer "infra_deployer"]];
+      ];
+      ocaml, "ocaml.org", [
+        (* New V3 ocaml.org website. *)
+        docker "Dockerfile" ["main", "ocurrent/v3.ocaml.org-server:live", [`OCamlorg_v3b "infra_www"]] ~options:include_git;
+        (* Staging branch for ocaml.org website. *)
+        docker "Dockerfile" ["staging", "ocurrent/v3.ocaml.org-server:staging", [`OCamlorg_v3c "infra_www"]] ~options:include_git
+      ];
+      ocaml, "v2.ocaml.org", [
+        (* Backup of existing ocaml.org website. *)
+        docker "Dockerfile.deploy"  ["master", "ocurrent/v2.ocaml.org:live", [`OCamlorg_v2 ["v2.ocaml.org", None]]] ~options:include_git;
+      ];
+      ocurrent, "docker-base-images", [
         (* Docker base images @ images.ci.ocaml.org *)
         docker "Dockerfile"     ["live", "ocurrent/base-images:live", [`Ocamlorg_images "base-images_builder"]];
       ];
-
-    ocurrent, "ocaml-docs-ci", [
+      ocurrent, "ocaml-docs-ci", [
         docker "Dockerfile"                 ["live", "ocurrent/docs-ci:live", [`Docs "infra_docs-ci"]];
         docker "docker/init/Dockerfile"     ["live", "ocurrent/docs-ci-init:live", [`Docs "infra_init"]];
         docker "docker/storage/Dockerfile"  ["live", "ocurrent/docs-ci-storage-server:live", [`Docs "infra_storage-server"]];
@@ -191,89 +181,126 @@ let ocaml_org ?app ?notify:channel ?filter ~sched ~staging_auth () =
         docker "docker/init/Dockerfile"     ["staging", "ocurrent/docs-ci-init:staging", [`Staging_docs "infra_init"]];
         docker "docker/storage/Dockerfile"  ["staging", "ocurrent/docs-ci-storage-server:staging", [`Staging_docs "infra_storage-server"]];
       ];
-    ]  in
+    ]
 
-  let head_of repo id =
-    match Build.api ocaml_opam with
-    | Some api ->
-      let id_type = match id with
-      | `Ref x -> `Ref x
-      | `PR pri -> `PR pri.Github.Api.Ref.id
+  let opam_repository ?app () =
+    (* GitHub organisations to monitor. *)
+    let ocaml_opam = Build.org ?app ~account:"ocaml-opam" 23690708 in
+    let pipelines =
+      [
+        ocaml_opam, "opam2web", [
+          docker_registry (Duration.of_min 360) "Dockerfile"
+            ["live", "opam.ocaml.org:live", [`Ocamlorg_opam4 "infra_opam_live"; `Ocamlorg_opam5 "infra_opam_live"];
+              "live-staging", "opam.ocaml.org:staging", [`Ocamlorg_opam4 "infra_opam_staging"; `Ocamlorg_opam5 "infra_opam_staging"]]
+        ];
+      ]
+    in
+    let head_of repo id =
+      match Build.api ocaml_opam with
+      | Some api ->
+        let id_type = match id with
+        | `Ref x -> `Ref x
+        | `PR pri -> `PR pri.Github.Api.Ref.id
+        in
+        Current.map Github.Api.Commit.id @@ Github.Api.head_of api repo id_type
+      | None -> Github.Api.Anonymous.head_of repo id
+    in
+    let additional_build_args =
+      let+ opam_repository_commit =
+        head_of { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } @@ `Ref "refs/heads/master"
+      and+ platform_blog_commit =
+        head_of { Github.Repo_id.owner = "ocaml"; name = "platform-blog" } @@ `Ref "refs/heads/master"
+      and+ opam_commit =
+        head_of { Github.Repo_id.owner = "ocaml"; name = "opam" } @@ `Ref "refs/heads/master"
       in
-      Current.map Github.Api.Commit.id @@ Github.Api.head_of api repo id_type
-    | None -> Github.Api.Anonymous.head_of repo id
-  in
+      [
+        "OPAM_REPO_GIT_SHA=" ^ Current_git.Commit_id.hash opam_repository_commit;
+        "BLOG_GIT_SHA=" ^ Current_git.Commit_id.hash platform_blog_commit;
+        "OPAM_GIT_SHA=" ^ Current_git.Commit_id.hash opam_commit
+      ]
+    in
+    pipelines, additional_build_args
 
-  let additional_build_args =
-    let+ opam_repository_commit =
-      head_of { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } @@ `Ref "refs/heads/master"
-    and+ platform_blog_commit =
-      head_of { Github.Repo_id.owner = "ocaml"; name = "platform-blog" } @@ `Ref "refs/heads/master"
-    and+ opam_commit =
-      head_of { Github.Repo_id.owner = "ocaml"; name = "opam" } @@ `Ref "refs/heads/master" in
-    ["OPAM_REPO_GIT_SHA=" ^ Current_git.Commit_id.hash opam_repository_commit;
-     "BLOG_GIT_SHA=" ^ Current_git.Commit_id.hash platform_blog_commit;
-     "OPAM_GIT_SHA=" ^ Current_git.Commit_id.hash opam_commit]
-  in
+  let extras () =
+    let tarsnap =
+      let monthly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
+      Current_ssh.run ~schedule:monthly "watch.ocaml.org" ~key:"tarsnap" (Current.return ["./tarsnap-backup.sh"])
+    in
+    let peertube =
+      let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) () in
+      let image = Cluster.Watch_docker.pull ~schedule:weekly "chocobozzz/peertube:production-bookworm" in
+      Cluster.Watch_docker.service ~name:"infra_peertube" ~image ()
+    in
+    [tarsnap; peertube]
 
-  let opam_repository_pipeline = filter_list filter [
-    ocaml_opam, "opam2web", [
-      docker_registry (Duration.of_min 360) "Dockerfile"
-      ["live", "opam.ocaml.org:live", [`Ocamlorg_opam4 "infra_opam_live"; `Ocamlorg_opam5 "infra_opam_live"];
-       "live-staging", "opam.ocaml.org:staging", [`Ocamlorg_opam4 "infra_opam_staging"; `Ocamlorg_opam5 "infra_opam_staging"]]
-    ];
-  ]
-  in
+  let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
+    (* [web_ui collapse_value] is a URL back to the deployment service, for links
+      in status messages. *)
+    let web_ui repo = Uri.with_query' base_url ["repo", repo] in
+    let build ?additional_build_args (org, name, builds) =
+      Cluster_build.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
+    in
+    let build_for_registry ?additional_build_args (org, name, builds) =
+      Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
+    in
+    let pipelines = filter_list filter @@ services ?app ~sched ~staging_auth () in
 
-  let monthly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
-  let tarsnap = Current_ssh.run ~schedule:monthly "watch.ocaml.org" ~key:"tarsnap" (Current.return ["./tarsnap-backup.sh"])
-  in
-  let peertube =
-    let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) () in
-    let image = Cluster.Watch_docker.pull ~schedule:weekly "chocobozzz/peertube:production-bookworm" in
-    Cluster.Watch_docker.service ~name:"infra_peertube" ~image ()
+    let opam_repository_pipelines, additional_build_args =
+      opam_repository ?app ()
+      |> (fun (pipelines, args) -> filter_list filter @@ pipelines, args)
+    in
+    Current.all (
+      (List.map (build_for_registry ~additional_build_args) opam_repository_pipelines)
+      @ (List.map build pipelines)
+      @ extras ())
+end
 
-  in
-  Current.all ((List.append
-                 (List.map (build_for_registry ~additional_build_args) opam_repository_pipeline)
-                 (List.map build pipelines)) @ [tarsnap; peertube])
+module Mirage = struct
+  let base_url = Uri.of_string "https://deploy.mirage.io/" 
 
-let unikernel dockerfile ~target args services =
-  let build_info = { Packet_unikernel.dockerfile; target; args } in
-  let deploys =
-    services
-    |> List.map (fun (branch, service) -> branch, { Packet_unikernel.service }) in
-  (build_info, deploys)
+  let unikernel dockerfile ~target args services =
+    let build_info = { Packet_unikernel.dockerfile; target; args } in
+    let deploys =
+      services
+      |> List.map (fun (branch, service) -> branch, { Packet_unikernel.service }) in
+    (build_info, deploys)
 
-let mirage ?app ?notify:channel ~sched ~staging_auth () =
-  (* [web_ui collapse_value] is a URL back to the deployment service, for links
-     in status messages. *)
-  let web_ui =
-    let base = Uri.of_string "https://deploy.mirage.io/" in
-    fun repo -> Uri.with_query' base ["repo", repo] in
+  let unikernel_services ?app () =
+    (* GitHub organisations to monitor. *)
+    let mirage = Build.org ?app ~account:"mirage" 7175142 in
+    [
+      mirage, "mirage-www", [
+        unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["master", "www"];
+        unikernel "Dockerfile" ~target:"xen" ["EXTRA_FLAGS=--tls=true"] [];     (* (no deployments) *)
+        unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["next", "next"];
+      ];
+    ]
 
-  (* GitHub organisations to monitor. *)
-  let mirage = Build.org ?app ~account:"mirage" 7175142 in
-  let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
-  let build_unikernel (org, name, builds) = Build_unikernel.repo ?channel ~web_ui ~org ~name builds in
-  let build_docker (org, name, builds) = Cluster_build.repo ?channel ~web_ui ~org ~name builds in
-  let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
-  let docker = docker ~sched in
-  Current.all @@ (List.map build_unikernel [
-    mirage, "mirage-www", [
-      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["master", "www"];
-      unikernel "Dockerfile" ~target:"xen" ["EXTRA_FLAGS=--tls=true"] [];     (* (no deployments) *)
-      unikernel "Dockerfile" ~target:"hvt" ["EXTRA_FLAGS=--tls=true --metrics --separate-networks"] ["next", "next"];
-    ];
-  ] @ List.map build_docker [
-    ocurrent, "mirage-ci", [
-      docker "Dockerfile" ["live", "ocurrent/mirage-ci:live", [`Cimirage "infra_mirage-ci"]]
-        ~options:(include_git |> build_kit)
-    ];
-    ocurrent, "ocurrent-deployer", [
-      docker "Dockerfile"     ["live-mirage", "ocurrent/deploy.mirage.io:live", [`Cimirage "infra_deployer"]];
-    ];
-    ocurrent, "caddy-rfc2136", [
-      docker "Dockerfile"     ["master", "ocurrent/caddy-rfc2136:live", [`Cimirage "infra_caddy"]];
-    ];
-  ])
+  let docker_services ?app ~staging_auth ~sched () =
+    (* GitHub organisations to monitor. *)
+    let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
+    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
+    let docker = docker ~sched in
+    [
+      ocurrent, "mirage-ci", [
+        docker "Dockerfile" ["live", "ocurrent/mirage-ci:live", [`Cimirage "infra_mirage-ci"]]
+          ~options:(include_git |> build_kit)
+      ];
+      ocurrent, "ocurrent-deployer", [
+        docker "Dockerfile"     ["live-mirage", "ocurrent/deploy.mirage.io:live", [`Cimirage "infra_deployer"]];
+      ];
+      ocurrent, "caddy-rfc2136", [
+        docker "Dockerfile"     ["master", "ocurrent/caddy-rfc2136:live", [`Cimirage "infra_caddy"]];
+      ];
+    ]
+
+  let v ?app ?notify:channel ~sched ~staging_auth () =
+    (* [web_ui collapse_value] is a URL back to the deployment service, for links
+      in status messages. *)
+    let web_ui repo = Uri.with_query' base_url ["repo", repo] in
+    let build_unikernel (org, name, builds) = Build_unikernel.repo ?channel ~web_ui ~org ~name builds in
+    let build_docker (org, name, builds) = Cluster_build.repo ?channel ~web_ui ~org ~name builds in
+    Current.all @@
+      ((List.map build_unikernel @@ unikernel_services ?app ())
+      @ (List.map build_docker @@ docker_services ?app ~staging_auth ~sched ()))
+end

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -7,25 +7,31 @@ module Flavour : sig
   val cmdliner : t Cmdliner.Term.t
 end
 
-val tarides :
-  ?app:Current_github.App.t ->
-  ?notify:Current_slack.channel ->
-  ?filter:(Current_github.Repo_id.t -> bool) ->
-  sched:Current_ocluster.Connection.t ->
-  staging_auth:(string * string) option ->
-  unit -> unit Current.t
+module Tarides : sig
+  val v :
+    ?app:Current_github.App.t ->
+    ?notify:Current_slack.channel ->
+    ?filter:(Current_github.Repo_id.t -> bool) ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit -> unit Current.t
+end
 
-val ocaml_org :
-  ?app:Current_github.App.t ->
-  ?notify:Current_slack.channel ->
-  ?filter:(Current_github.Repo_id.t -> bool) ->
-  sched:Current_ocluster.Connection.t ->
-  staging_auth:(string * string) option ->
-  unit -> unit Current.t
+module Ocaml_org : sig
+  val v :
+    ?app:Current_github.App.t ->
+    ?notify:Current_slack.channel ->
+    ?filter:(Current_github.Repo_id.t -> bool) ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit -> unit Current.t
+end
 
-val mirage :
-  ?app:Current_github.App.t ->
-  ?notify:Current_slack.channel ->
-  sched:Current_ocluster.Connection.t ->
-  staging_auth:(string * string) option ->
-  unit -> unit Current.t
+module Mirage : sig
+  val v :
+    ?app:Current_github.App.t ->
+    ?notify:Current_slack.channel ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit -> unit Current.t
+end


### PR DESCRIPTION
Currently the list of services is fed directly into a single `Current.unit` pipeline, this PR separates them out so that we can generate documentation from the list of services.

Future PRs for documentation and testing will depend on this PR. It is broken up to keep reviews manageable.
