### PR TITLE
Generate list of services as documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ various other pipelines we use. When a new commit is pushed to the
 `live` branch of a source repository, it builds a new Docker image
 for the project and upgrades the service to that version.
 
-> The list of deployed services is located in [services.md][].
+The list of deployed services is located in [doc/services.md][].
 
 The main configuration is in [pipeline.ml][]. For example, one entry is:
 
@@ -102,4 +102,4 @@ To update a deployment that is managed by ocurrent-deployer (which could be ocur
 [MirageOS]: https://mirage.io/
 [Albatross]: https://github.com/hannesm/albatross
 [pipeline.ml]: ./src/pipeline.ml
-[services.md]: ./doc/services.md
+[doc/services.md]: ./doc/services.md

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ various other pipelines we use. When a new commit is pushed to the
 `live` branch of a source repository, it builds a new Docker image
 for the project and upgrades the service to that version.
 
+> The list of deployed services is located in [services.md][].
+
 The main configuration is in [pipeline.ml][]. For example, one entry is:
 
 ```ocaml
@@ -100,3 +102,4 @@ To update a deployment that is managed by ocurrent-deployer (which could be ocur
 [MirageOS]: https://mirage.io/
 [Albatross]: https://github.com/hannesm/albatross
 [pipeline.ml]: ./src/pipeline.ml
+[services.md]: ./doc/services.md

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -26,7 +26,6 @@ let output_service (org, name, dockers) =
     let dockers =
       List.map output_docker dockers
       |> List.flatten
-      (* |> List.map (fun x -> "  " ^ x) *)
     in
     Some (String.concat "\n" (header @ dockers))
 

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -5,32 +5,60 @@ let has_deployments t =
     (fun t -> t.Pipeline.services != [])
     t.Pipeline.targets
 
-let output_archs archs =
+let show_archs archs =
   String.concat ", " @@ List.map Cluster.Arch.to_string archs
 
-let output_docker t =
+let show_github_link ~org ~name branch =
+  Printf.sprintf "https://github.com/%s/%s/tree/%s" org name branch
+
+let show_docker_hub_link tag =
+  let url =
+    match String.split_on_char ':' tag with
+    | [] -> None
+    | org_and_name :: _ ->
+      Some (Printf.sprintf "https://hub.docker.com/r/%s" org_and_name)
+  in
+  match url with
+  | None -> Printf.sprintf "`%s`" tag
+  | Some url -> Printf.sprintf "[`%s`](%s)" tag url
+
+let show_docker ~org ~name t =
   if not (has_deployments t) then []
   else
-    let header = [
-      Printf.sprintf "- `%s` on arches: %s" t.dockerfile (output_archs t.archs)
-    ] in
-    let deployments =
-      List.map (fun t -> Printf.sprintf "  - branch `%s` at `%s`" t.Pipeline.branch t.target) t.targets 
+    let header =
+      Printf.sprintf "- `%s` on arches: %s" t.dockerfile (show_archs t.archs)
     in
-    header @ deployments
+    let deployments =
+      List.map
+        (fun t ->
+          Printf.sprintf
+            "  - branch [`%s`](%s) built at %s"
+            t.Pipeline.branch
+            (show_github_link ~org ~name t.branch)
+            (show_docker_hub_link t.target))
+        t.targets
+    in
+    header :: deployments
 
-let output_service (org, name, dockers) =
-  if List.for_all (fun x -> not (has_deployments x)) dockers then None
+let show_service (org, name, dockers) =
+  if not @@ List.exists has_deployments dockers then None
   else
-    let header = [ Printf.sprintf "## %s/%s" (Build.account org) name ] in
+    let org = Build.account org in
+    let header = [ Printf.sprintf "### [%s/%s](https://github.com/%s/%s)" org name org name ] in
     let dockers =
-      List.map output_docker dockers
+      List.map (show_docker ~org ~name) dockers
       |> List.flatten
     in
     Some (String.concat "\n" (header @ dockers))
 
 let () =
   Printf.printf "# Deployed CI services\n\n";
-  Pipeline.Tarides.services ()
-  |> List.filter_map output_service
-  |> List.iter (Printf.printf "%s\n\n")
+  Printf.printf "For a given service, the specified Dockerfile is pulled from the specified branch and built to produce an image, which is then pushed to Docker Hub with the specified tag.\n\n";
+  let f label services =
+    Printf.printf "## %s\n\n" label;
+    List.filter_map show_service services
+    |> List.iter (Printf.printf "%s\n\n")
+  in
+  f "Tarides services" @@ Pipeline.Tarides.services ();
+  f "OCaml Org services" @@ Pipeline.Ocaml_org.services ();
+  f "Mirage Docker services" @@ Pipeline.Mirage.docker_services ()

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -1,0 +1,58 @@
+open Deployer
+
+let has_deployments t =
+  List.exists
+    (fun t -> t.Pipeline.services != [])
+    t.Pipeline.targets
+
+let output_archs archs =
+  String.concat ", " @@ List.map Cluster.Arch.to_string archs
+
+let output_docker t =
+  if not (has_deployments t) then []
+  else
+    let header = [
+      Printf.sprintf "- `%s` on arches: %s" t.dockerfile (output_archs t.archs)
+    ] in
+    let deployments =
+      List.map (fun t -> Printf.sprintf "  - branch `%s` at `%s`" t.Pipeline.branch t.target) t.targets 
+    in
+    header @ deployments
+
+let output_service (org, name, dockers) =
+  if List.for_all (fun x -> not (has_deployments x)) dockers then None
+  else
+    let header = [ Printf.sprintf "### %s/%s" (Build.account org) name ] in
+    let dockers =
+      List.map output_docker dockers
+      |> List.flatten
+      (* |> List.map (fun x -> "  " ^ x) *)
+    in
+    Some (String.concat "\n" (header @ dockers))
+
+let main outfile =
+  let oc = open_out outfile in
+  Printf.fprintf oc "## Deployed CI services\n\n";
+  Pipeline.Tarides.services ()
+  |> List.filter_map output_service
+  |> List.iter (Printf.fprintf oc "%s\n\n");
+  close_out oc
+
+(* Command-line parsing *)
+open Cmdliner
+
+let outfile =
+  Arg.required @@
+  Arg.opt Arg.(some string) None @@
+  Arg.info
+    ~doc:"The destination file for the list of services."
+    ~docv:"OUTFILE"
+    ["out"; "o"]
+
+let cmd =
+  let doc = "Generate documentation for the list of services" in
+  let info = Cmd.info "doc" ~doc in
+  let cmd_t = Term.(const main $ outfile) in
+  Cmd.v info cmd_t
+
+let () = exit (Cmd.eval cmd)

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -22,36 +22,15 @@ let output_docker t =
 let output_service (org, name, dockers) =
   if List.for_all (fun x -> not (has_deployments x)) dockers then None
   else
-    let header = [ Printf.sprintf "### %s/%s" (Build.account org) name ] in
+    let header = [ Printf.sprintf "## %s/%s" (Build.account org) name ] in
     let dockers =
       List.map output_docker dockers
       |> List.flatten
     in
     Some (String.concat "\n" (header @ dockers))
 
-let main outfile =
-  let oc = open_out outfile in
-  Printf.fprintf oc "## Deployed CI services\n\n";
+let () =
+  Printf.printf "# Deployed CI services\n\n";
   Pipeline.Tarides.services ()
   |> List.filter_map output_service
-  |> List.iter (Printf.fprintf oc "%s\n\n");
-  close_out oc
-
-(* Command-line parsing *)
-open Cmdliner
-
-let outfile =
-  Arg.required @@
-  Arg.opt Arg.(some string) None @@
-  Arg.info
-    ~doc:"The destination file for the list of services."
-    ~docv:"OUTFILE"
-    ["out"; "o"]
-
-let cmd =
-  let doc = "Generate documentation for the list of services" in
-  let info = Cmd.info "doc" ~doc in
-  let cmd_t = Term.(const main $ outfile) in
-  Cmd.v info cmd_t
-
-let () = exit (Cmd.eval cmd)
+  |> List.iter (Printf.printf "%s\n\n")

--- a/doc/dune
+++ b/doc/dune
@@ -3,8 +3,9 @@
  (libraries deployer))
 
 (rule
-  (target services-new.md)
-  (action (run ./doc.exe -o %{target})))
+ (target services-new.md)
+ (action
+  (with-stdout-to %{target} (run ./doc.exe))))
 
 (rule
  (alias doc)

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,13 @@
+(executable
+ (name doc)
+ (libraries deployer))
+
+(rule
+  (target services-new.md)
+  (action (run ./doc.exe -o %{target})))
+
+(rule
+ (alias doc)
+ (mode promote)
+ (action
+  (diff ./services.md ./services-new.md)))

--- a/doc/services.md
+++ b/doc/services.md
@@ -1,43 +1,95 @@
 # Deployed CI services
 
-## ocurrent/ocurrent-deployer
-- `Dockerfile` on arches: x86_64
-  - branch `live-ci3` at `ocurrent/ci.ocamllabs.io-deployer:live-ci3`
+For a given service, the specified Dockerfile is pulled from the specified branch and built to produce an image, which is then pushed to Docker Hub with the specified tag.
 
-## ocurrent/ocaml-ci
+## Tarides services
+
+### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+- `Dockerfile` on arches: x86_64
+  - branch [`live-ci3`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ci3) built at [`ocurrent/ci.ocamllabs.io-deployer:live-ci3`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+
+### [ocurrent/ocaml-ci](https://github.com/ocurrent/ocaml-ci)
 - `Dockerfile` on arches: x86_64, arm64
-  - branch `live-engine` at `ocurrent/ocaml-ci-service:live`
+  - branch [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine) built at [`ocurrent/ocaml-ci-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-service)
 - `Dockerfile.gitlab` on arches: x86_64, arm64
-  - branch `live-engine` at `ocurrent/ocaml-ci-gitlab-service:live`
+  - branch [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine) built at [`ocurrent/ocaml-ci-gitlab-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-gitlab-service)
 - `Dockerfile.web` on arches: x86_64, arm64
-  - branch `live-www` at `ocurrent/ocaml-ci-web:live`
-  - branch `staging-www` at `ocurrent/ocaml-ci-web:staging`
+  - branch [`live-www`](https://github.com/ocurrent/ocaml-ci/tree/live-www) built at [`ocurrent/ocaml-ci-web:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
+  - branch [`staging-www`](https://github.com/ocurrent/ocaml-ci/tree/staging-www) built at [`ocurrent/ocaml-ci-web:staging`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
 
-## ocurrent/opam-repo-ci
+### [ocurrent/opam-repo-ci](https://github.com/ocurrent/opam-repo-ci)
 - `Dockerfile` on arches: x86_64, arm64
-  - branch `live` at `ocurrent/opam-repo-ci:live`
+  - branch [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live) built at [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
 - `Dockerfile.web` on arches: x86_64, arm64
-  - branch `live-web` at `ocurrent/opam-repo-ci-web:live`
+  - branch [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web) built at [`ocurrent/opam-repo-ci-web:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci-web)
 
-## ocurrent/opam-health-check
+### [ocurrent/opam-health-check](https://github.com/ocurrent/opam-health-check)
 - `Dockerfile` on arches: x86_64
-  - branch `live` at `ocurrent/opam-health-check:live`
+  - branch [`live`](https://github.com/ocurrent/opam-health-check/tree/live) built at [`ocurrent/opam-health-check:live`](https://hub.docker.com/r/ocurrent/opam-health-check)
 
-## ocurrent/ocaml-multicore-ci
+### [ocurrent/ocaml-multicore-ci](https://github.com/ocurrent/ocaml-multicore-ci)
 - `Dockerfile` on arches: x86_64
-  - branch `live` at `ocurrent/multicore-ci:live`
+  - branch [`live`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live) built at [`ocurrent/multicore-ci:live`](https://hub.docker.com/r/ocurrent/multicore-ci)
 - `Dockerfile.web` on arches: x86_64
-  - branch `live-web` at `ocurrent/multicore-ci-web:live`
+  - branch [`live-web`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live-web) built at [`ocurrent/multicore-ci-web:live`](https://hub.docker.com/r/ocurrent/multicore-ci-web)
 
-## ocurrent/ocurrent.org
+### [ocurrent/ocurrent.org](https://github.com/ocurrent/ocurrent.org)
 - `Dockerfile` on arches: x86_64
-  - branch `live-engine` at `ocurrent/ocurrent.org:live-engine`
+  - branch [`live-engine`](https://github.com/ocurrent/ocurrent.org/tree/live-engine) built at [`ocurrent/ocurrent.org:live-engine`](https://hub.docker.com/r/ocurrent/ocurrent.org)
 
-## ocaml-bench/sandmark-nightly
+### [ocaml-bench/sandmark-nightly](https://github.com/ocaml-bench/sandmark-nightly)
 - `Dockerfile` on arches: x86_64
-  - branch `main` at `ocurrent/sandmark-nightly:live`
+  - branch [`main`](https://github.com/ocaml-bench/sandmark-nightly/tree/main) built at [`ocurrent/sandmark-nightly:live`](https://hub.docker.com/r/ocurrent/sandmark-nightly)
 
-## ocurrent/multicoretests-ci
+### [ocurrent/multicoretests-ci](https://github.com/ocurrent/multicoretests-ci)
 - `Dockerfile` on arches: x86_64
-  - branch `live` at `ocurrent/multicoretests-ci:live`
+  - branch [`live`](https://github.com/ocurrent/multicoretests-ci/tree/live) built at [`ocurrent/multicoretests-ci:live`](https://hub.docker.com/r/ocurrent/multicoretests-ci)
+
+## OCaml Org services
+
+### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+- `Dockerfile` on arches: x86_64
+  - branch [`live-ocaml-org`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ocaml-org) built at [`ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+
+### [ocaml/ocaml.org](https://github.com/ocaml/ocaml.org)
+- `Dockerfile` on arches: x86_64
+  - branch [`main`](https://github.com/ocaml/ocaml.org/tree/main) built at [`ocurrent/v3.ocaml.org-server:live`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+- `Dockerfile` on arches: x86_64
+  - branch [`staging`](https://github.com/ocaml/ocaml.org/tree/staging) built at [`ocurrent/v3.ocaml.org-server:staging`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+
+### [ocaml/v2.ocaml.org](https://github.com/ocaml/v2.ocaml.org)
+- `Dockerfile.deploy` on arches: x86_64
+  - branch [`master`](https://github.com/ocaml/v2.ocaml.org/tree/master) built at [`ocurrent/v2.ocaml.org:live`](https://hub.docker.com/r/ocurrent/v2.ocaml.org)
+
+### [ocurrent/docker-base-images](https://github.com/ocurrent/docker-base-images)
+- `Dockerfile` on arches: x86_64
+  - branch [`live`](https://github.com/ocurrent/docker-base-images/tree/live) built at [`ocurrent/base-images:live`](https://hub.docker.com/r/ocurrent/base-images)
+
+### [ocurrent/ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci)
+- `Dockerfile` on arches: x86_64
+  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci:live`](https://hub.docker.com/r/ocurrent/docs-ci)
+- `docker/init/Dockerfile` on arches: x86_64
+  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci-init:live`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+- `docker/storage/Dockerfile` on arches: x86_64
+  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci-storage-server:live`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+- `Dockerfile` on arches: x86_64
+  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci:staging`](https://hub.docker.com/r/ocurrent/docs-ci)
+- `docker/init/Dockerfile` on arches: x86_64
+  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci-init:staging`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+- `docker/storage/Dockerfile` on arches: x86_64
+  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci-storage-server:staging`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+
+## Mirage Docker services
+
+### [ocurrent/mirage-ci](https://github.com/ocurrent/mirage-ci)
+- `Dockerfile` on arches: x86_64
+  - branch [`live`](https://github.com/ocurrent/mirage-ci/tree/live) built at [`ocurrent/mirage-ci:live`](https://hub.docker.com/r/ocurrent/mirage-ci)
+
+### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+- `Dockerfile` on arches: x86_64
+  - branch [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage) built at [`ocurrent/deploy.mirage.io:live`](https://hub.docker.com/r/ocurrent/deploy.mirage.io)
+
+### [ocurrent/caddy-rfc2136](https://github.com/ocurrent/caddy-rfc2136)
+- `Dockerfile` on arches: x86_64
+  - branch [`master`](https://github.com/ocurrent/caddy-rfc2136/tree/master) built at [`ocurrent/caddy-rfc2136:live`](https://hub.docker.com/r/ocurrent/caddy-rfc2136)
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -1,0 +1,43 @@
+## Deployed CI services
+
+### ocurrent/ocurrent-deployer
+- `Dockerfile` on arches: x86_64
+  - branch `live-ci3` at `ocurrent/ci.ocamllabs.io-deployer:live-ci3`
+
+### ocurrent/ocaml-ci
+- `Dockerfile` on arches: x86_64, arm64
+  - branch `live-engine` at `ocurrent/ocaml-ci-service:live`
+- `Dockerfile.gitlab` on arches: x86_64, arm64
+  - branch `live-engine` at `ocurrent/ocaml-ci-gitlab-service:live`
+- `Dockerfile.web` on arches: x86_64, arm64
+  - branch `live-www` at `ocurrent/ocaml-ci-web:live`
+  - branch `staging-www` at `ocurrent/ocaml-ci-web:staging`
+
+### ocurrent/opam-repo-ci
+- `Dockerfile` on arches: x86_64, arm64
+  - branch `live` at `ocurrent/opam-repo-ci:live`
+- `Dockerfile.web` on arches: x86_64, arm64
+  - branch `live-web` at `ocurrent/opam-repo-ci-web:live`
+
+### ocurrent/opam-health-check
+- `Dockerfile` on arches: x86_64
+  - branch `live` at `ocurrent/opam-health-check:live`
+
+### ocurrent/ocaml-multicore-ci
+- `Dockerfile` on arches: x86_64
+  - branch `live` at `ocurrent/multicore-ci:live`
+- `Dockerfile.web` on arches: x86_64
+  - branch `live-web` at `ocurrent/multicore-ci-web:live`
+
+### ocurrent/ocurrent.org
+- `Dockerfile` on arches: x86_64
+  - branch `live-engine` at `ocurrent/ocurrent.org:live-engine`
+
+### ocaml-bench/sandmark-nightly
+- `Dockerfile` on arches: x86_64
+  - branch `main` at `ocurrent/sandmark-nightly:live`
+
+### ocurrent/multicoretests-ci
+- `Dockerfile` on arches: x86_64
+  - branch `live` at `ocurrent/multicoretests-ci:live`
+

--- a/doc/services.md
+++ b/doc/services.md
@@ -1,10 +1,10 @@
-## Deployed CI services
+# Deployed CI services
 
-### ocurrent/ocurrent-deployer
+## ocurrent/ocurrent-deployer
 - `Dockerfile` on arches: x86_64
   - branch `live-ci3` at `ocurrent/ci.ocamllabs.io-deployer:live-ci3`
 
-### ocurrent/ocaml-ci
+## ocurrent/ocaml-ci
 - `Dockerfile` on arches: x86_64, arm64
   - branch `live-engine` at `ocurrent/ocaml-ci-service:live`
 - `Dockerfile.gitlab` on arches: x86_64, arm64
@@ -13,31 +13,31 @@
   - branch `live-www` at `ocurrent/ocaml-ci-web:live`
   - branch `staging-www` at `ocurrent/ocaml-ci-web:staging`
 
-### ocurrent/opam-repo-ci
+## ocurrent/opam-repo-ci
 - `Dockerfile` on arches: x86_64, arm64
   - branch `live` at `ocurrent/opam-repo-ci:live`
 - `Dockerfile.web` on arches: x86_64, arm64
   - branch `live-web` at `ocurrent/opam-repo-ci-web:live`
 
-### ocurrent/opam-health-check
+## ocurrent/opam-health-check
 - `Dockerfile` on arches: x86_64
   - branch `live` at `ocurrent/opam-health-check:live`
 
-### ocurrent/ocaml-multicore-ci
+## ocurrent/ocaml-multicore-ci
 - `Dockerfile` on arches: x86_64
   - branch `live` at `ocurrent/multicore-ci:live`
 - `Dockerfile.web` on arches: x86_64
   - branch `live-web` at `ocurrent/multicore-ci-web:live`
 
-### ocurrent/ocurrent.org
+## ocurrent/ocurrent.org
 - `Dockerfile` on arches: x86_64
   - branch `live-engine` at `ocurrent/ocurrent.org:live-engine`
 
-### ocaml-bench/sandmark-nightly
+## ocaml-bench/sandmark-nightly
 - `Dockerfile` on arches: x86_64
   - branch `main` at `ocurrent/sandmark-nightly:live`
 
-### ocurrent/multicoretests-ci
+## ocurrent/multicoretests-ci
 - `Dockerfile` on arches: x86_64
   - branch `live` at `ocurrent/multicoretests-ci:live`
 

--- a/src/aws.ml
+++ b/src/aws.ml
@@ -12,6 +12,12 @@ type t = {
   certificate: string;
 }
 
+let show t = t.name
+
+let pp ppf t =
+  Format.pp_print_string ppf @@
+  Printf.sprintf "%s/%s" t.name t.branch
+
 let command_colon = function
   | None -> ""
   | Some cmd -> "    command: " ^ cmd ^ "\n"

--- a/src/build.ml
+++ b/src/build.ml
@@ -6,17 +6,23 @@ let timeout = Duration.of_min 50
 let password_path = "/run/secrets/ocurrent-hub"
 let push_repo = "ocurrentbuilder/staging"
 
-let auth =
-  if Sys.file_exists password_path then (
-    let ch = open_in_bin password_path in
-    let len = in_channel_length ch in
-    let password = really_input_string ch len |> String.trim in
-    close_in ch;
-    Some ("ocurrent", password)
-  ) else (
-    Fmt.pr "Password file %S not found; images will not be pushed to hub@." password_path;
-    None
-  )
+let auth : (string * string) option option ref = ref None
+
+let get_auth () =
+  match !auth with
+  | Some a -> a
+  | None ->
+    if Sys.file_exists password_path then (
+      let ch = open_in_bin password_path in
+      let len = in_channel_length ch in
+      let password = really_input_string ch len |> String.trim in
+      close_in ch;
+      auth := Some (Some ("ocurrent", password))
+    ) else (
+      Logs.warn (fun f -> f "Password file %S not found; images will not be pushed to hub@." password_path);
+      auth := Some (None)
+    );
+    Option.join !auth
 
 type org = string * Current_github.Api.t option
 

--- a/src/build.mli
+++ b/src/build.mli
@@ -8,7 +8,7 @@ val password_path : string
 val push_repo : string
 (** Docker hub tag for the repo we push to *)
 
-val auth : (string * string) option
+val get_auth : unit -> (string * string) option
 (** The username and password for logging in, if found *)
 
 val org :

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -144,7 +144,7 @@ let pull_and_serve (module D : Current_docker.S.DOCKER) ~name op repo_id =
   let image =
     Current.component "pull" |>
     let> repo_id in
-    Current_docker.Raw.pull repo_id ?auth:Build.auth ~docker_context:D.docker_context ~schedule:no_schedule
+    Current_docker.Raw.pull repo_id ?auth:(Build.get_auth ()) ~docker_context:D.docker_context ~schedule:no_schedule
     |> Current.Primitive.map_result (Result.map (fun raw_image ->
         D.Image.of_hash (Current_docker.Raw.Image.hash raw_image)
       ))
@@ -205,7 +205,7 @@ let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(addition
     build_and_push sched ~options ~push_target ~pool ~src dockerfile
   in
   let images = List.map build_arch archs in
-  match Build.auth with
+  match Build.get_auth () with
   | None -> Current.all (Current.fail "No auth configured; can't push final image" :: List.map Current.ignore_value images)
   | Some auth ->
     let multi_hash = Current_docker.push_manifest ~auth images ~tag:(Cluster_api.Docker.Image_id.to_string hub_id) in

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -15,6 +15,13 @@ module Arch = struct
     | `Linux_ppc64 -> "linux-ppc64"
     | `Linux_s390x -> "linux-s390x"
     | `Linux_riscv64 -> "linux-riscv64"
+
+  let to_string : t -> string = function
+    | `Linux_arm64 -> "arm64"
+    | `Linux_x86_64 -> "x86_64"
+    | `Linux_ppc64 -> "ppc64"
+    | `Linux_s390x -> "s390x"
+    | `Linux_riscv64 -> "riscv64"
 end
 
 let push_repo = "ocurrentbuilder/staging"
@@ -70,9 +77,6 @@ type deploy_info = {
   hub_id : Cluster_api.Docker.Image_id.t;
   services : service list;
 }
-
-(* type service_info =
-  Build.org * string * (build_info * (string * deploy_info) list) list *)
 
 let show_service (org, name, builds) =
   let builds =

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -64,15 +64,25 @@ type service = [
   | `OCamlorg_v3b of string                  (* OCaml website @ v3b.ocaml.org aka www.ocaml.org *)
   | `OCamlorg_v3c of string                  (* Staging OCaml website @ staging.ocaml.org *)
   | `Aws_ecs of Aws.t                        (* Amazon Web Services - Elastic Container Service *)
-]
+] [@@deriving show]
 
 type deploy_info = {
   hub_id : Cluster_api.Docker.Image_id.t;
   services : service list;
 }
 
-type service_info =
-  Build.org * string * (build_info * (string * deploy_info) list) list
+(* type service_info =
+  Build.org * string * (build_info * (string * deploy_info) list) list *)
+
+let show_service (org, name, builds) =
+  let builds =
+    List.map
+      (fun (build, _deploys) ->
+        Printf.sprintf "%s" (Cluster_api.Docker.Image_id.to_string build))
+      builds
+    |> String.concat "\n"
+  in
+  Printf.sprintf "- %s/%s\n%s" (Build.account org) name builds
 
 let get_job_id x =
   let+ md = Current.Analysis.metadata x in

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -71,6 +71,9 @@ type deploy_info = {
   services : service list;
 }
 
+type service_info =
+  Build.org * string * (build_info * (string * deploy_info) list) list
+
 let get_job_id x =
   let+ md = Current.Analysis.metadata x in
   match md with

--- a/src/docker_registry.ml
+++ b/src/docker_registry.ml
@@ -23,7 +23,7 @@ type deploy_info = {
   services : service list;
 }
 
-let auth = match Build.auth with
+let auth () = match Build.get_auth () with
   | Some (user, pass) -> Some (user ^ "@" ^ host, pass)
   | None -> None
 
@@ -57,7 +57,7 @@ let pull_and_serve (module D : Current_docker.S.DOCKER) ~name repo_id =
     Current.component "pull" |>
     let> repo_id in
     Current_docker.Raw.pull repo_id
-    ?auth
+    ?auth:(auth ())
     ~docker_context:D.docker_context
     ~schedule:no_schedule
     |> Current.Primitive.map_result (Result.map (fun raw_image ->
@@ -69,7 +69,7 @@ let pull_and_serve (module D : Current_docker.S.DOCKER) ~name repo_id =
 let deploy build_info { tag; services } ?(additional_build_args=Current.return []) src =
   let image = build_image build_info additional_build_args src in
   let tag = host ^ "/" ^ tag in
-  let repo_id = Docker.push ~tag image ?auth in
+  let repo_id = Docker.push ~tag image ?auth:(auth ()) in
   Current.all (
     List.map (fun service ->
       match service with

--- a/src/packet_unikernel.ml
+++ b/src/packet_unikernel.ml
@@ -12,6 +12,9 @@ type deploy_info = {
   service : string;
 }
 
+type service_info =
+  Build.org * string * (build_info * (string * deploy_info) list) list
+
 let build_image { dockerfile; target; args } src =
   let src = Current_git.fetch src in
   let args = ("TARGET=" ^ target) :: args in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -30,11 +30,11 @@ module Cluster_build = Build.Make(Cluster)
 
 type deployment = {
   branch : string;
-  target : string;
+  target : string; (* The docker tag of the image that the branch is built to *)
   services : Cluster.service list;
 }
 
-let make_deployment branch target services = { branch; target; services; }
+let make_deployment ~branch ~target services = { branch; target; services; }
 
 type docker = {
   dockerfile : string;
@@ -94,8 +94,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live-ci3"
-              "ocurrent/ci.ocamllabs.io-deployer:live-ci3"
+              ~branch:"live-ci3"
+              ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ci3"
               [`Ci3 "deployer_deployer"];
           ]
       ];
@@ -104,8 +104,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live-engine"
-              "ocurrent/ocaml-ci-service:live"
+              ~branch:"live-engine"
+              ~target:"ocurrent/ocaml-ci-service:live"
               [`Ci "ocaml-ci_ci"];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
@@ -113,8 +113,8 @@ module Tarides = struct
           "Dockerfile.gitlab"
           [
             make_deployment
-              "live-engine"
-              "ocurrent/ocaml-ci-gitlab-service:live"
+              ~branch:"live-engine"
+              ~target:"ocurrent/ocaml-ci-gitlab-service:live"
               [`Ci "ocaml-ci_gitlab"];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
@@ -122,12 +122,12 @@ module Tarides = struct
           "Dockerfile.web"
           [
             make_deployment
-              "live-www"
-              "ocurrent/ocaml-ci-web:live"
+              ~branch:"live-www"
+              ~target:"ocurrent/ocaml-ci-web:live"
               [`Ci "ocaml-ci_web"];
             make_deployment
-              "staging-www"
-              "ocurrent/ocaml-ci-web:staging"
+              ~branch:"staging-www"
+              ~target:"ocurrent/ocaml-ci-web:staging"
               [`Ci "test-www"];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
@@ -137,8 +137,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live-scheduler"
-              "ocurrent/ocluster-scheduler:live"
+              ~branch:"live-scheduler"
+              ~target:"ocurrent/ocluster-scheduler:live"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64]
@@ -147,8 +147,8 @@ module Tarides = struct
           "Dockerfile.worker"
           [
             make_deployment
-              "live-worker"
-              "ocurrent/ocluster-worker:live"
+              ~branch:"live-worker"
+              ~target:"ocurrent/ocluster-worker:live"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64]
@@ -157,8 +157,8 @@ module Tarides = struct
           "Dockerfile.worker.alpine"
           [
             make_deployment
-              "live-worker"
-              "ocurrent/ocluster-worker:alpine"
+              ~branch:"live-worker"
+              ~target:"ocurrent/ocluster-worker:alpine"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
@@ -168,8 +168,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/clarke:live"
+              ~branch:"live"
+              ~target:"ocurrent/clarke:live"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
@@ -179,8 +179,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/opam-repo-ci:live"
+              ~branch:"live"
+              ~target:"ocurrent/opam-repo-ci:live"
               [`Opamrepo "opam-repo-ci_opam-repo-ci"];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
@@ -188,8 +188,8 @@ module Tarides = struct
           "Dockerfile.web"
           [
             make_deployment
-              "live-web"
-              "ocurrent/opam-repo-ci-web:live"
+              ~branch:"live-web"
+              ~target:"ocurrent/opam-repo-ci-web:live"
               [`Opamrepo "opam-repo-ci_opam-repo-ci-web"];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
@@ -199,8 +199,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/opam-health-check:live"
+              ~branch:"live"
+              ~target:"ocurrent/opam-health-check:live"
               [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"];
           ];
       ];
@@ -209,16 +209,16 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/multicore-ci:live"
+              ~branch:"live"
+              ~target:"ocurrent/multicore-ci:live"
               [`Ci4 "infra_multicore-ci"];
           ];
         make_docker
           "Dockerfile.web"
           [
             make_deployment
-              "live-web"
-              "ocurrent/multicore-ci-web:live"
+              ~branch:"live-web"
+              ~target:"ocurrent/multicore-ci-web:live"
               [`Ci4 "infra_multicore-ci-web"];
           ];
       ];
@@ -227,8 +227,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live-engine"
-              "ocurrent/ocurrent.org:live-engine"
+              ~branch:"live-engine"
+              ~target:"ocurrent/ocurrent.org:live-engine"
               [`Ci3 "ocurrent_org_watcher"];
           ];
       ];
@@ -237,8 +237,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "main"
-              "ocurrent/sandmark-nightly:live"
+              ~branch:"main"
+              ~target:"ocurrent/sandmark-nightly:live"
               [`Ci3 "sandmark_sandmark"];
           ]
           ~options:include_git;
@@ -248,8 +248,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/solver-service:live"
+              ~branch:"live"
+              ~target:"ocurrent/solver-service:live"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
@@ -257,8 +257,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "staging"
-              "ocurrent/solver-service:staging"
+              ~branch:"staging"
+              ~target:"ocurrent/solver-service:staging"
               [];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
@@ -268,8 +268,8 @@ module Tarides = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/multicoretests-ci:live"
+              ~branch:"live"
+              ~target:"ocurrent/multicoretests-ci:live"
               [`Ci4 "infra_multicoretests-ci"];
           ];
       ];
@@ -317,8 +317,8 @@ module Ocaml_org = struct
           "Dockerfile"
           [
             make_deployment
-              "live-ocaml-org"
-              "ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
+              ~branch:"live-ocaml-org"
+              ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
               [`Ocamlorg_deployer "infra_deployer"];
           ];
       ];
@@ -328,8 +328,8 @@ module Ocaml_org = struct
           "Dockerfile"
           [
             make_deployment
-              "main"
-              "ocurrent/v3.ocaml.org-server:live"
+              ~branch:"main"
+              ~target:"ocurrent/v3.ocaml.org-server:live"
               [`OCamlorg_v3b "infra_www"]
           ]
           ~options:include_git;
@@ -338,8 +338,8 @@ module Ocaml_org = struct
           "Dockerfile"
           [
             make_deployment
-              "staging"
-              "ocurrent/v3.ocaml.org-server:staging"
+              ~branch:"staging"
+              ~target:"ocurrent/v3.ocaml.org-server:staging"
               [`OCamlorg_v3c "infra_www"]
           ]
           ~options:include_git
@@ -350,8 +350,8 @@ module Ocaml_org = struct
           "Dockerfile.deploy"
           [
             make_deployment
-              "master"
-              "ocurrent/v2.ocaml.org:live"
+              ~branch:"master"
+              ~target:"ocurrent/v2.ocaml.org:live"
               [`OCamlorg_v2 ["v2.ocaml.org", None]];
           ]
           ~options:include_git;
@@ -362,8 +362,8 @@ module Ocaml_org = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/base-images:live"
+              ~branch:"live"
+              ~target:"ocurrent/base-images:live"
               [`Ocamlorg_images "base-images_builder"];
           ];
       ];
@@ -372,48 +372,48 @@ module Ocaml_org = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/docs-ci:live"
+              ~branch:"live"
+              ~target:"ocurrent/docs-ci:live"
               [`Docs "infra_docs-ci"];
           ];
         make_docker
           "docker/init/Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/docs-ci-init:live"
+              ~branch:"live"
+              ~target:"ocurrent/docs-ci-init:live"
               [`Docs "infra_init"];
           ];
         make_docker
           "docker/storage/Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/docs-ci-storage-server:live"
+              ~branch:"live"
+              ~target:"ocurrent/docs-ci-storage-server:live"
               [`Docs "infra_storage-server"];
           ];
         make_docker
           "Dockerfile"
           [
             make_deployment
-              "staging"
-              "ocurrent/docs-ci:staging"
+              ~branch:"staging"
+              ~target:"ocurrent/docs-ci:staging"
               [`Staging_docs "infra_docs-ci"];
           ];
         make_docker
           "docker/init/Dockerfile"
           [
             make_deployment
-              "staging"
-              "ocurrent/docs-ci-init:staging"
+              ~branch:"staging"
+              ~target:"ocurrent/docs-ci-init:staging"
               [`Staging_docs "infra_init"];
           ];
         make_docker
           "docker/storage/Dockerfile"
           [
             make_deployment
-              "staging"
-              "ocurrent/docs-ci-storage-server:staging"
+              ~branch:"staging"
+              ~target:"ocurrent/docs-ci-storage-server:staging"
               [`Staging_docs "infra_storage-server"];
           ];
       ];
@@ -530,8 +530,8 @@ module Mirage = struct
           "Dockerfile"
           [
             make_deployment
-              "live"
-              "ocurrent/mirage-ci:live"
+              ~branch:"live"
+              ~target:"ocurrent/mirage-ci:live"
               [`Cimirage "infra_mirage-ci"]
           ]
           ~options:(include_git |> build_kit)
@@ -541,8 +541,8 @@ module Mirage = struct
           "Dockerfile"
           [
             make_deployment
-              "live-mirage"
-              "ocurrent/deploy.mirage.io:live"
+              ~branch:"live-mirage"
+              ~target:"ocurrent/deploy.mirage.io:live"
               [`Cimirage "infra_deployer"]
           ];
       ];
@@ -551,8 +551,8 @@ module Mirage = struct
           "Dockerfile"
           [
             make_deployment
-              "master"
-              "ocurrent/caddy-rfc2136:live"
+              ~branch:"master"
+              ~target:"ocurrent/caddy-rfc2136:live"
               [`Cimirage "infra_caddy"]
           ];
       ];

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -237,8 +237,8 @@ module Ocaml_org = struct
     (* [web_ui collapse_value] is a URL back to the deployment service, for links
       in status messages. *)
     let web_ui repo = Uri.with_query' base_url ["repo", repo] in
-    let build ?additional_build_args (org, name, builds) =
-      Cluster_build.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
+    let build (org, name, builds) =
+      Cluster_build.repo ?channel ~web_ui ~org ~name builds
     in
     let build_for_registry ?additional_build_args (org, name, builds) =
       Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
@@ -276,7 +276,7 @@ module Mirage = struct
       ];
     ]
 
-  let docker_services ?app ~staging_auth ~sched () =
+  let docker_services ?app ~sched ~staging_auth () =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
     let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -28,11 +28,31 @@ module Build_unikernel = Build.Make(Packet_unikernel)
 module Build_registry = Build.Make(Docker_registry)
 module Cluster_build = Build.Make(Cluster)
 
-let docker ?(archs=[`Linux_x86_64]) ?(options=Cluster_api.Docker.Spec.defaults) ~sched dockerfile targets =
+type deployment = {
+  branch : string;
+  target : string;
+  services : Cluster.service list;
+}
+
+let make_deployment branch target services = { branch; target; services; }
+
+type docker = {
+  dockerfile : string;
+  targets : deployment list;
+  archs : Cluster.Arch.t list;
+  options : Cluster_api.Docker.Spec.options;
+}
+
+let make_docker ?(archs=[`Linux_x86_64]) ?(options=Cluster_api.Docker.Spec.defaults) dockerfile targets =
+  { dockerfile; targets; archs; options }
+
+type service = Build.org * string * docker list
+
+let docker ~sched { dockerfile; targets; archs; options } =
   let build_info = { Cluster.sched; dockerfile = `Path dockerfile; options; archs } in
   let deploys =
     targets
-    |> List.map (fun (branch, target, services) ->
+    |> List.map (fun { branch; target; services } ->
         branch, { Cluster.
                   hub_id = Cluster_api.Docker.Image_id.of_string target |> or_fail;
                   services
@@ -64,72 +84,204 @@ module Tarides = struct
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
     the service, and where to deploy it. *)
-  let services ?app ~sched ~staging_auth () =
+  let services ?app () =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 12497518 in
     let ocaml_bench = Build.org ?app ~account:"ocaml-bench" 19839896 in
-    let docker ?archs =
-      let timeout = match archs with
-        | Some archs when List.mem `Linux_riscv64 archs -> Int64.mul Build.timeout 2L
-        | _ -> Build.timeout
-      in
-      docker ?archs ~sched:(Current_ocluster.v ~timeout ?push_auth:staging_auth sched)
-    in
     [
       ocurrent, "ocurrent-deployer", [
-        docker "Dockerfile"     ["live-ci3",   "ocurrent/ci.ocamllabs.io-deployer:live-ci3",   [`Ci3 "deployer_deployer"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-ci3"
+              "ocurrent/ci.ocamllabs.io-deployer:live-ci3"
+              [`Ci3 "deployer_deployer"];
+          ]
       ];
       ocurrent, "ocaml-ci", [
-        docker "Dockerfile"     ["live-engine", "ocurrent/ocaml-ci-service:live", [`Ci "ocaml-ci_ci"]]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-engine"
+              "ocurrent/ocaml-ci-service:live"
+              [`Ci "ocaml-ci_ci"];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
-        docker "Dockerfile.gitlab" ["live-engine", "ocurrent/ocaml-ci-gitlab-service:live", [`Ci "ocaml-ci_gitlab"]]
+        make_docker
+          "Dockerfile.gitlab"
+          [
+            make_deployment
+              "live-engine"
+              "ocurrent/ocaml-ci-gitlab-service:live"
+              [`Ci "ocaml-ci_gitlab"];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
-        docker "Dockerfile.web" ["live-www",    "ocurrent/ocaml-ci-web:live",     [`Ci "ocaml-ci_web"];
-                                "staging-www", "ocurrent/ocaml-ci-web:staging",  [`Ci "test-www"]]
+        make_docker
+          "Dockerfile.web"
+          [
+            make_deployment
+              "live-www"
+              "ocurrent/ocaml-ci-web:live"
+              [`Ci "ocaml-ci_web"];
+            make_deployment
+              "staging-www"
+              "ocurrent/ocaml-ci-web:staging"
+              [`Ci "test-www"];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
       ocurrent, "ocluster", [
-        docker "Dockerfile"        ["live-scheduler", "ocurrent/ocluster-scheduler:live", []]
-          ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
-        docker "Dockerfile.worker" ["live-worker",    "ocurrent/ocluster-worker:live", []]
-          ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64] ~options:(include_git |> fun v ->  { v with build_args =  ["--ulimit stack=1000000000:1000000000"]});
-        docker "Dockerfile.worker.alpine" ["live-worker",    "ocurrent/ocluster-worker:alpine", []]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-scheduler"
+              "ocurrent/ocluster-scheduler:live"
+              [];
+          ]
+          ~archs:[`Linux_x86_64; `Linux_arm64]
+          ~options:include_git;
+        make_docker
+          "Dockerfile.worker"
+          [
+            make_deployment
+              "live-worker"
+              "ocurrent/ocluster-worker:live"
+              [];
+          ]
+          ~archs:[`Linux_x86_64; `Linux_arm64; `Linux_ppc64; `Linux_s390x; `Linux_riscv64]
+          ~options:(include_git |> fun v ->  { v with build_args =  ["--ulimit stack=1000000000:1000000000"]});
+        make_docker
+          "Dockerfile.worker.alpine"
+          [
+            make_deployment
+              "live-worker"
+              "ocurrent/ocluster-worker:alpine"
+              [];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
       ocurrent, "clarke", [
-        docker "Dockerfile" ["live",   "ocurrent/clarke:live", []]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/clarke:live"
+              [];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
       ocurrent, "opam-repo-ci", [
-        docker "Dockerfile"     ["live", "ocurrent/opam-repo-ci:live", [`Opamrepo "opam-repo-ci_opam-repo-ci"]]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/opam-repo-ci:live"
+              [`Opamrepo "opam-repo-ci_opam-repo-ci"];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
-        docker "Dockerfile.web" ["live-web", "ocurrent/opam-repo-ci-web:live", [`Opamrepo "opam-repo-ci_opam-repo-ci-web"]]
+        make_docker
+          "Dockerfile.web"
+          [
+            make_deployment
+              "live-web"
+              "ocurrent/opam-repo-ci-web:live"
+              [`Opamrepo "opam-repo-ci_opam-repo-ci-web"];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
       ocurrent, "opam-health-check", [
-        docker "Dockerfile" ["live", "ocurrent/opam-health-check:live", [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/opam-health-check:live"
+              [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"];
+          ];
       ];
       ocurrent, "ocaml-multicore-ci", [
-        docker "Dockerfile"     ["live", "ocurrent/multicore-ci:live", [`Ci4 "infra_multicore-ci"]];
-        docker "Dockerfile.web" ["live-web", "ocurrent/multicore-ci-web:live", [`Ci4 "infra_multicore-ci-web"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/multicore-ci:live"
+              [`Ci4 "infra_multicore-ci"];
+          ];
+        make_docker
+          "Dockerfile.web"
+          [
+            make_deployment
+              "live-web"
+              "ocurrent/multicore-ci-web:live"
+              [`Ci4 "infra_multicore-ci-web"];
+          ];
       ];
       ocurrent, "ocurrent.org", [
-        docker "Dockerfile"     ["live-engine", "ocurrent/ocurrent.org:live-engine", [`Ci3 "ocurrent_org_watcher"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-engine"
+              "ocurrent/ocurrent.org:live-engine"
+              [`Ci3 "ocurrent_org_watcher"];
+          ];
       ];
       ocaml_bench, "sandmark-nightly", [
-        docker "Dockerfile" ["main", "ocurrent/sandmark-nightly:live", [`Ci3 "sandmark_sandmark"]]
-        ~options:include_git;
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "main"
+              "ocurrent/sandmark-nightly:live"
+              [`Ci3 "sandmark_sandmark"];
+          ]
+          ~options:include_git;
       ];
       ocurrent, "solver-service", [
-        docker "Dockerfile" ["live", "ocurrent/solver-service:live", []]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/solver-service:live"
+              [];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
-        docker "Dockerfile" ["staging", "ocurrent/solver-service:staging", []]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "staging"
+              "ocurrent/solver-service:staging"
+              [];
+          ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
       ocurrent, "multicoretests-ci", [
-        docker "Dockerfile" ["live", "ocurrent/multicoretests-ci:live", [`Ci4 "infra_multicoretests-ci"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/multicoretests-ci:live"
+              [`Ci4 "infra_multicoretests-ci"];
+          ];
       ];
     ]
+
+  let docker ~sched ~staging_auth t =
+    let timeout =
+      if List.mem `Linux_riscv64 t.archs then Int64.mul Build.timeout 2L
+      else Build.timeout
+    in
+    let sched = Current_ocluster.v ~timeout ?push_auth:staging_auth sched in
+    docker ~sched t
 
   let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
     (* [web_ui collapse_value] is a URL back to the deployment service, for links
@@ -138,8 +290,14 @@ module Tarides = struct
     let build (org, name, builds) =
       Cluster_build.repo ?channel ~web_ui ~org ~name builds
     in
-    Current.all @@ List.map build @@ filter_list filter @@
-      services ?app ~sched ~staging_auth ()
+    let docker = docker ~sched ~staging_auth in
+    services ?app ()
+    |> List.map (fun (org, name, deployments) ->
+      let deployments = List.map docker deployments in
+      (org, name, deployments))
+    |> filter_list filter
+    |> List.map build
+    |> Current.all
 end
 
 module Ocaml_org = struct
@@ -149,37 +307,115 @@ module Ocaml_org = struct
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
     the service, and where to deploy it. *)
-  let services ?app ~sched ~staging_auth () =
+  let services ?app () =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 23342906 in
     let ocaml = Build.org ?app ~account:"ocaml" 23711648 in
-    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
-    let docker = docker ~sched in
     [
       ocurrent, "ocurrent-deployer", [
-        docker "Dockerfile"     ["live-ocaml-org", "ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org", [`Ocamlorg_deployer "infra_deployer"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-ocaml-org"
+              "ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
+              [`Ocamlorg_deployer "infra_deployer"];
+          ];
       ];
       ocaml, "ocaml.org", [
         (* New V3 ocaml.org website. *)
-        docker "Dockerfile" ["main", "ocurrent/v3.ocaml.org-server:live", [`OCamlorg_v3b "infra_www"]] ~options:include_git;
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "main"
+              "ocurrent/v3.ocaml.org-server:live"
+              [`OCamlorg_v3b "infra_www"]
+          ]
+          ~options:include_git;
         (* Staging branch for ocaml.org website. *)
-        docker "Dockerfile" ["staging", "ocurrent/v3.ocaml.org-server:staging", [`OCamlorg_v3c "infra_www"]] ~options:include_git
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "staging"
+              "ocurrent/v3.ocaml.org-server:staging"
+              [`OCamlorg_v3c "infra_www"]
+          ]
+          ~options:include_git
       ];
       ocaml, "v2.ocaml.org", [
         (* Backup of existing ocaml.org website. *)
-        docker "Dockerfile.deploy"  ["master", "ocurrent/v2.ocaml.org:live", [`OCamlorg_v2 ["v2.ocaml.org", None]]] ~options:include_git;
+        make_docker
+          "Dockerfile.deploy"
+          [
+            make_deployment
+              "master"
+              "ocurrent/v2.ocaml.org:live"
+              [`OCamlorg_v2 ["v2.ocaml.org", None]];
+          ]
+          ~options:include_git;
       ];
       ocurrent, "docker-base-images", [
         (* Docker base images @ images.ci.ocaml.org *)
-        docker "Dockerfile"     ["live", "ocurrent/base-images:live", [`Ocamlorg_images "base-images_builder"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/base-images:live"
+              [`Ocamlorg_images "base-images_builder"];
+          ];
       ];
       ocurrent, "ocaml-docs-ci", [
-        docker "Dockerfile"                 ["live", "ocurrent/docs-ci:live", [`Docs "infra_docs-ci"]];
-        docker "docker/init/Dockerfile"     ["live", "ocurrent/docs-ci-init:live", [`Docs "infra_init"]];
-        docker "docker/storage/Dockerfile"  ["live", "ocurrent/docs-ci-storage-server:live", [`Docs "infra_storage-server"]];
-        docker "Dockerfile"                 ["staging", "ocurrent/docs-ci:staging", [`Staging_docs "infra_docs-ci"]];
-        docker "docker/init/Dockerfile"     ["staging", "ocurrent/docs-ci-init:staging", [`Staging_docs "infra_init"]];
-        docker "docker/storage/Dockerfile"  ["staging", "ocurrent/docs-ci-storage-server:staging", [`Staging_docs "infra_storage-server"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/docs-ci:live"
+              [`Docs "infra_docs-ci"];
+          ];
+        make_docker
+          "docker/init/Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/docs-ci-init:live"
+              [`Docs "infra_init"];
+          ];
+        make_docker
+          "docker/storage/Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/docs-ci-storage-server:live"
+              [`Docs "infra_storage-server"];
+          ];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "staging"
+              "ocurrent/docs-ci:staging"
+              [`Staging_docs "infra_docs-ci"];
+          ];
+        make_docker
+          "docker/init/Dockerfile"
+          [
+            make_deployment
+              "staging"
+              "ocurrent/docs-ci-init:staging"
+              [`Staging_docs "infra_init"];
+          ];
+        make_docker
+          "docker/storage/Dockerfile"
+          [
+            make_deployment
+              "staging"
+              "ocurrent/docs-ci-storage-server:staging"
+              [`Staging_docs "infra_storage-server"];
+          ];
       ];
     ]
 
@@ -243,7 +479,16 @@ module Ocaml_org = struct
     let build_for_registry ?additional_build_args (org, name, builds) =
       Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
     in
-    let pipelines = filter_list filter @@ services ?app ~sched ~staging_auth () in
+    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
+    let docker = docker ~sched in
+    let pipelines =
+      services ?app ()
+      |> List.map (fun (org, name, deployments) ->
+        let deployments = List.map docker deployments in
+        (org, name, deployments))
+      |> filter_list filter
+      |> List.map build
+    in
     let opam_repository_pipelines, additional_build_args =
       let pipelines, args = opam_repository ?app () in
       let filtered_pipelines = filter_list filter @@ pipelines in
@@ -251,7 +496,7 @@ module Ocaml_org = struct
     in
     Current.all (
       (List.map (build_for_registry ~additional_build_args) opam_repository_pipelines)
-      @ (List.map build pipelines)
+      @ pipelines
       @ extras ())
 end
 
@@ -276,21 +521,40 @@ module Mirage = struct
       ];
     ]
 
-  let docker_services ?app ~sched ~staging_auth () =
+  let docker_services ?app () =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
-    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
-    let docker = docker ~sched in
     [
       ocurrent, "mirage-ci", [
-        docker "Dockerfile" ["live", "ocurrent/mirage-ci:live", [`Cimirage "infra_mirage-ci"]]
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live"
+              "ocurrent/mirage-ci:live"
+              [`Cimirage "infra_mirage-ci"]
+          ]
           ~options:(include_git |> build_kit)
       ];
       ocurrent, "ocurrent-deployer", [
-        docker "Dockerfile"     ["live-mirage", "ocurrent/deploy.mirage.io:live", [`Cimirage "infra_deployer"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "live-mirage"
+              "ocurrent/deploy.mirage.io:live"
+              [`Cimirage "infra_deployer"]
+          ];
       ];
       ocurrent, "caddy-rfc2136", [
-        docker "Dockerfile"     ["master", "ocurrent/caddy-rfc2136:live", [`Cimirage "infra_caddy"]];
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              "master"
+              "ocurrent/caddy-rfc2136:live"
+              [`Cimirage "infra_caddy"]
+          ];
       ];
     ]
 
@@ -300,7 +564,16 @@ module Mirage = struct
     let web_ui repo = Uri.with_query' base_url ["repo", repo] in
     let build_unikernel (org, name, builds) = Build_unikernel.repo ?channel ~web_ui ~org ~name builds in
     let build_docker (org, name, builds) = Cluster_build.repo ?channel ~web_ui ~org ~name builds in
+    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
+    let docker = docker ~sched in
+    let docker_services =
+      docker_services ?app ()
+      |> List.map (fun (org, name, deployments) ->
+        let deployments = List.map docker deployments in
+        (org, name, deployments))
+      |> List.map build_docker
+    in
     Current.all @@
       ((List.map build_unikernel @@ unikernel_services ?app ())
-      @ (List.map build_docker @@ docker_services ?app ~staging_auth ~sched ()))
+      @ docker_services)
 end

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -7,13 +7,23 @@ module Flavour : sig
   val cmdliner : t Cmdliner.Term.t
 end
 
+type deployment = {
+  branch : string;
+  target : string;
+  services : Cluster.service list;
+}
+
+type docker = {
+  dockerfile : string;
+  targets : deployment list;
+  archs : Cluster.Arch.t list;
+  options : Cluster_api.Docker.Spec.options;
+}
+
+type service = Build.org * string * docker list
+
 module Tarides : sig
-  val services :
-    ?app:Current_github.App.t ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit ->
-    Cluster.service_info list
+  val services : ?app:Current_github.App.t -> unit -> service list
 
   val v :
     ?app:Current_github.App.t ->
@@ -25,12 +35,7 @@ module Tarides : sig
 end
 
 module Ocaml_org : sig
-  val services :
-    ?app:Current_github.App.t ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit ->
-    Cluster.service_info list
+  val services : ?app:Current_github.App.t -> unit -> service list
 
   val v :
     ?app:Current_github.App.t ->
@@ -47,12 +52,7 @@ module Mirage : sig
     unit ->
     Packet_unikernel.service_info list
 
-  val docker_services :
-    ?app:Current_github.App.t ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit ->
-    Cluster.service_info list
+  val docker_services : ?app:Current_github.App.t -> unit -> service list
 
   val v :
     ?app:Current_github.App.t ->

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -8,6 +8,13 @@ module Flavour : sig
 end
 
 module Tarides : sig
+  val services :
+    ?app:Current_github.App.t ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit ->
+    Cluster.service_info list
+
   val v :
     ?app:Current_github.App.t ->
     ?notify:Current_slack.channel ->
@@ -18,6 +25,13 @@ module Tarides : sig
 end
 
 module Ocaml_org : sig
+  val services :
+    ?app:Current_github.App.t ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit ->
+    Cluster.service_info list
+
   val v :
     ?app:Current_github.App.t ->
     ?notify:Current_slack.channel ->
@@ -28,6 +42,18 @@ module Ocaml_org : sig
 end
 
 module Mirage : sig
+  val unikernel_services :
+    ?app:Current_github.App.t ->
+    unit ->
+    Packet_unikernel.service_info list
+
+  val docker_services :
+    ?app:Current_github.App.t ->
+    sched:Current_ocluster.Connection.t ->
+    staging_auth:(string * string) option ->
+    unit ->
+    Cluster.service_info list
+
   val v :
     ?app:Current_github.App.t ->
     ?notify:Current_slack.channel ->


### PR DESCRIPTION
Run `dune build @doc` to generate a markdown file documenting the list of services, which can be `dune promote`ed if it differs from the existing one. This also serves as an expect test.

The section at the bottom is an excerpt from the new `services.md`. We include the dockerfiles that are deployed, and for which branches and docker tags. We don't include the specific targets — e.g. `` `Ci3 ``, `` `Opamrepo ``, etc. — but this can be included if it would be useful.

A particular note is that the code in `pipeline.ml` includes services for which there are no deployments, such as `clarke`, likely just as a way to keep track of them. These services are not included in `services.md`.

---

...

### ocurrent/opam-repo-ci
- `Dockerfile` on arches: x86_64, arm64
  - branch `live` at `ocurrent/opam-repo-ci:live`
- `Dockerfile.web` on arches: x86_64, arm64
  - branch `live-web` at `ocurrent/opam-repo-ci-web:live`

### ocurrent/opam-health-check
- `Dockerfile` on arches: x86_64
  - branch `live` at `ocurrent/opam-health-check:live`

...