### PR TITLE
Remove explicit installation of Docker Compose CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get install libffi-dev libev4 openssh-client curl gnup
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin -y --no-install-recommends
-RUN curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocurrent-deployer"]
 COPY create-config.sh create-config.sh


### PR DESCRIPTION
The Docker Compose CLI project has been retired.  See https://github.com/docker-archive/compose-cli.

This plugin was needed to provide support for pushing to Amazon ECS.  However, we do not currently deploy to ECS so this can be dropped and revisited if we ever decide to use ECS.