### PR TITLE
Remove v2.ocaml.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-12-ocaml-4.14@sha256:06d58a5cb1ab7875e8d94848102be43f6492e95320e8e9a9ecb9167654d0ee3f as build
+FROM ocaml/opam:debian-12-ocaml-4.14@sha256:06d58a5cb1ab7875e8d94848102be43f6492e95320e8e9a9ecb9167654d0ee3f AS build
 RUN sudo apt-get update && sudo apt-get install libffi-dev libev-dev m4 pkg-config libsqlite3-dev libgmp-dev libssl-dev capnproto graphviz -y --no-install-recommends
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 6d3d7021d944058cc7531905e065fe2cd72f01e8 && opam update
 COPY --chown=opam \

--- a/create-config.sh
+++ b/create-config.sh
@@ -11,7 +11,6 @@ docker context create "docs.ci.ocaml.org" --description "OCaml - docs.ci.ocaml.o
 docker context create "staging.docs.ci.ocamllabs.io" --description "Staging for docs.ci.ocaml.org" --docker "host=ssh://root@staging.docs.ci.ocamllabs.io"
 docker context create "opam-4.ocaml.org" --description "OPAM - opam-4.ocaml.org" --docker "host=ssh://root@opam-4.ocaml.org"
 docker context create "opam-5.ocaml.org" --description "OPAM - opam-5.ocaml.org" --docker "host=ssh://root@opam-5.ocaml.org"
-docker context create "v2.ocaml.org" --description "OCaml - v2.ocaml.org" --docker "host=ssh://root@v2.ocaml.org"
 docker context create "v3b.ocaml.org" --description "OCaml - www.ocaml.org" --docker "host=ssh://root@v3b.ocaml.org"
 docker context create "v3c.ocaml.org" --description "OCaml - staging.ocaml.org" --docker "host=ssh://root@v3c.ocaml.org"
 docker context create "watch.ocaml.org" --description "OCaml - watch.ocaml.org" --docker "host=ssh://root@watch.ocaml.org"
@@ -39,7 +38,6 @@ for host in \
   staging.docs.ci.ocamllabs.io \
   opam-4.ocaml.org \
   opam-5.ocaml.org \
-  v2.ocaml.org \
   v3b.ocaml.org \
   v3c.ocaml.org \
   watch.ocaml.org \

--- a/doc/services.md
+++ b/doc/services.md
@@ -57,10 +57,6 @@ For a given service, the specified Dockerfile is pulled from the specified branc
 - `Dockerfile` on arches: x86_64
   - branch [`staging`](https://github.com/ocaml/ocaml.org/tree/staging) built at [`ocurrent/v3.ocaml.org-server:staging`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
 
-### [ocaml/v2.ocaml.org](https://github.com/ocaml/v2.ocaml.org)
-- `Dockerfile.deploy` on arches: x86_64
-  - branch [`master`](https://github.com/ocaml/v2.ocaml.org/tree/master) built at [`ocurrent/v2.ocaml.org:live`](https://hub.docker.com/r/ocurrent/v2.ocaml.org)
-
 ### [ocurrent/docker-base-images](https://github.com/ocurrent/docker-base-images)
 - `Dockerfile` on arches: x86_64
   - branch [`live`](https://github.com/ocurrent/docker-base-images/tree/live) built at [`ocurrent/base-images:live`](https://hub.docker.com/r/ocurrent/base-images)

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -344,18 +344,6 @@ module Ocaml_org = struct
           ]
           ~options:include_git
       ];
-      ocaml, "v2.ocaml.org", [
-        (* Backup of existing ocaml.org website. *)
-        make_docker
-          "Dockerfile.deploy"
-          [
-            make_deployment
-              ~branch:"master"
-              ~target:"ocurrent/v2.ocaml.org:live"
-              [`OCamlorg_v2 ["v2.ocaml.org", None]];
-          ]
-          ~options:include_git;
-      ];
       ocurrent, "docker-base-images", [
         (* Docker base images @ images.ci.ocaml.org *)
         make_docker


### PR DESCRIPTION
v2.ocaml.org is now a redirect to ocaml.org.