### PR TITLE
Refactor the API of the modules that define the "flavours" of deployer pipelines

### DIFF
--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -61,4 +61,4 @@ let () =
   in
   f "Tarides services" @@ Pipeline.Tarides.services ();
   f "OCaml Org services" @@ Pipeline.Ocaml_org.services ();
-  f "Mirage Docker services" @@ Pipeline.Mirage.docker_services ()
+  f "Mirage Docker services" @@ Pipeline.Mirage.services ()

--- a/src/access.ml
+++ b/src/access.ml
@@ -1,0 +1,7 @@
+let user_has_role ~admins user role =
+  match role with
+  | `Viewer | `Monitor -> true (* Anyone can view view and monitor *)
+  | `Builder | `Admin ->
+    match user with
+    | None -> false (* Unauthenticated user *)
+    | Some u -> List.mem u admins

--- a/src/access.mli
+++ b/src/access.mli
@@ -1,0 +1,1 @@
+val user_has_role : admins:string list -> string option -> Current_web.Role.t -> bool

--- a/src/dune
+++ b/src/dune
@@ -48,6 +48,19 @@
   lwt
   lwt.unix
   prometheus-app.unix)
- (modules index pipeline aws caddy logging mirage s build cluster packet_unikernel docker_registry metrics)
+ (modules
+  index
+  pipeline
+  aws
+  caddy
+  logging
+  mirage
+  s
+  build
+  cluster
+  packet_unikernel
+  docker_registry
+  metrics
+  access)
  (preprocess
   (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/src/main.ml
+++ b/src/main.ml
@@ -23,87 +23,32 @@ let read_channel_uri path =
   with ex ->
     Fmt.failwith "Failed to read slack URI from %S: %a" path Fmt.exn ex
 
-(* Access control policy for Tarides. *)
-let has_role_tarides user role =
-  match user with
-  | None -> role = `Viewer || role = `Monitor         (* Unauthenticated users can only look at things. *)
-  | Some user ->
-    match Current_web.User.id user, role with
-    | ("github:talex5"
-      |"github:avsm"
-      |"github:shonfeder"
-      |"github:samoht"
-      |"github:tmcgilchrist"
-      |"github:mtelvers"
-      |"github:dra27"
-      |"github:moyodiallo"
-      |"github:punchagan"
-      |"github:MisterDA"
-      ), _ -> true        (* These users have all roles *)
-    | _ -> role = `Viewer
-
-(* Access control policy for Mirage. *)
-let has_role_mirage user role =
-  match user with
-  | None -> role = `Viewer || role = `Monitor         (* Unauthenticated users can only look at things. *)
-  | Some user ->
-    match Current_web.User.id user, role with
-    | ("github:talex5"
-      |"github:hannesm"
-      |"github:avsm"
-      |"github:shonfeder"
-      |"github:samoht"
-      |"github:tmcgilchrist"
-      |"github:mtelvers"
-      |"github:dra27"
-      |"github:moyodiallo"
-      |"github:punchagan"
-      ), _ -> true        (* These users have all roles *)
-    | _ -> role = `Viewer
-
-(* Access control policy for OCaml. *)
-let has_role_ocaml user role =
-  match user with
-  | None -> role = `Viewer || role = `Monitor         (* Unauthenticated users can only look at things. *)
-  | Some user ->
-    match Current_web.User.id user, role with
-    | ("github:talex5"
-      |"github:avsm"
-      |"github:shonfeder"
-      |"github:samoht"
-      |"github:tmcgilchrist"
-      |"github:mtelvers"
-      |"github:dra27"
-      |"github:rjbou"
-      |"github:AltGr"
-      |"github:moyodiallo"
-      |"github:punchagan"
-      ), _ -> true        (* These users have all roles *)
-    | _ -> role = `Viewer
-
 let main () config mode app slack auth staging_password_file flavour prometheus_config =
   let vat = Capnp_rpc_unix.client_only_vat () in
   let channel = read_channel_uri slack in
   let staging_auth = staging_password_file |> Option.map (fun path -> staging_user, read_first_line path) in
-  let engine = match flavour with
+  let engine, admins = match flavour with
     | Tarides sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Tarides.v ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Tarides.v ~app ~notify:channel ~sched ~staging_auth),
+       Pipeline.Tarides.admins
     | OCaml sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Ocaml_org.v ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Ocaml_org.v ~app ~notify:channel ~sched ~staging_auth),
+       Pipeline.Ocaml_org.admins
     | Mirage sched ->
        let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Mirage.v ~app ~notify:channel ~sched ~staging_auth)
+       Current.Engine.create ~config (Pipeline.Mirage.v ~app ~notify:channel ~sched ~staging_auth),
+       Pipeline.Mirage.admins
   in
   let authn = Option.map Current_github.Auth.make_login_uri auth in
   let webhook_secret = Current_github.App.webhook_secret app in
   let has_role =
-    if auth = None then Current_web.Site.allow_all
-    else match flavour with
-      | Tarides _ -> has_role_tarides
-      | Mirage _ -> has_role_mirage
-      | OCaml _ -> has_role_ocaml
+    if auth = None then
+      Current_web.Site.allow_all
+    else
+      fun user role ->
+        Access.user_has_role ~admins (Option.map Current_web.User.id user) role
   in
   let routes =
     Routes.(s "login" /? nil @--> Current_github.Auth.login auth) ::

--- a/src/main.ml
+++ b/src/main.ml
@@ -2,11 +2,6 @@
 
 open Deployer
 
-type flavour_opt =
-  | Tarides of Uri.t
-  | OCaml of Uri.t
-  | Mirage of Uri.t
-
 (* A low-security Docker Hub user used to push images to the staging area.
    Low-security because we never rely on the tags in this repository, just the hashes. *)
 let staging_user = "ocurrentbuilder"
@@ -23,26 +18,19 @@ let read_channel_uri path =
   with ex ->
     Fmt.failwith "Failed to read slack URI from %S: %a" path Fmt.exn ex
 
-let main () config mode app slack auth staging_password_file flavour prometheus_config =
+let main () config mode app slack auth staging_password_file (flavour, sched) prometheus_config =
   let vat = Capnp_rpc_unix.client_only_vat () in
   let channel = read_channel_uri slack in
   let staging_auth = staging_password_file |> Option.map (fun path -> staging_user, read_first_line path) in
-  let engine, admins = match flavour with
-    | Tarides sched ->
-       let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Tarides.v ~app ~notify:channel ~sched ~staging_auth),
-       Pipeline.Tarides.admins
-    | OCaml sched ->
-       let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Ocaml_org.v ~app ~notify:channel ~sched ~staging_auth),
-       Pipeline.Ocaml_org.admins
-    | Mirage sched ->
-       let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
-       Current.Engine.create ~config (Pipeline.Mirage.v ~app ~notify:channel ~sched ~staging_auth),
-       Pipeline.Mirage.admins
-  in
   let authn = Option.map Current_github.Auth.make_login_uri auth in
   let webhook_secret = Current_github.App.webhook_secret app in
+  let sched = Current_ocluster.Connection.create (Capnp_rpc_unix.Vat.import_exn vat sched) in
+  let pipeline, admins = match flavour with
+    | `Tarides -> Pipeline.Tarides.(v, admins)
+    | `OCaml -> Pipeline.Ocaml_org.(v, admins)
+    | `Mirage -> Pipeline.Mirage.(v, admins)
+  in
+  let engine = Current.Engine.create ~config (pipeline ~app ~notify:channel ~sched ~staging_auth) in
   let has_role =
     if auth = None then
       Current_web.Site.allow_all
@@ -84,15 +72,12 @@ let submission_service =
     ~docv:"FILE"
     ["submission-service"]
 
-let flavour_opt =
-  let f s fl : flavour_opt Term.ret = match s,fl with
-    | Some s, `OCaml -> `Ok (OCaml s)
-    | Some s, `Tarides -> `Ok (Tarides s)
-    | Some s, `Mirage -> `Ok (Mirage s)
-    | None, `Mirage -> `Error (true, "--submission-service required for --flavour mirage")
-    | None, `OCaml -> `Error (true, "--submission-service required for --flavour ocaml")
-    | None, `Tarides -> `Error (true, "--submission-service required for --flavour tarides") in
-
+let flavour_and_sub_service =
+  let f sub_service flavor : (Pipeline.Flavour.t * Uri.t) Term.ret = match sub_service with
+    | Some s -> `Ok (flavor, s)
+    | None ->
+      `Error (true, "--submission-service required for --flavour " ^ (Pipeline.Flavour.to_string flavor))
+  in
   Term.(ret (const f $ submission_service $ Pipeline.Flavour.cmdliner))
 
 let staging_password =
@@ -106,7 +91,7 @@ let staging_password =
 let cmd =
   let doc = "build and deploy services from Git" in
   let cmd_t = Term.(term_result (const main $ Logging.cmdliner $ Current.Config.cmdliner $ Current_web.cmdliner $
-        Current_github.App.cmdliner $ slack $ Current_github.Auth.cmdliner $ staging_password $ flavour_opt
+        Current_github.App.cmdliner $ slack $ Current_github.Auth.cmdliner $ staging_password $ flavour_and_sub_service
         $ Prometheus_unix.opts)) in
   let info = Cmd.info "deploy" ~doc in
   Cmd.v info cmd_t

--- a/src/main.ml
+++ b/src/main.ml
@@ -38,7 +38,6 @@ let has_role_tarides user role =
       |"github:dra27"
       |"github:moyodiallo"
       |"github:punchagan"
-      |"github:benmandrew"
       |"github:MisterDA"
       ), _ -> true        (* These users have all roles *)
     | _ -> role = `Viewer
@@ -58,6 +57,7 @@ let has_role_mirage user role =
       |"github:mtelvers"
       |"github:dra27"
       |"github:moyodiallo"
+      |"github:punchagan"
       ), _ -> true        (* These users have all roles *)
     | _ -> role = `Viewer
 
@@ -78,7 +78,6 @@ let has_role_ocaml user role =
       |"github:AltGr"
       |"github:moyodiallo"
       |"github:punchagan"
-      |"github:benmandrew"
       ), _ -> true        (* These users have all roles *)
     | _ -> role = `Viewer
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -54,20 +54,21 @@ let make_docker ?(archs=[`Linux_x86_64]) ?(options=Cluster_api.Docker.Spec.defau
 
 type service = Build.org * string * docker list
 
+type pipeline =
+  ?app:Current_github.App.t ->
+  ?notify:Current_slack.channel ->
+  ?filter:(Current_github.Repo_id.t -> bool) ->
+  sched:Current_ocluster.Connection.t ->
+  staging_auth:(string * string) option ->
+  unit ->
+  unit Current.t
+
 module type Constellation = sig
   (** The interface for a pipelines that deploys a constellation of services *)
 
   val services : ?app:Current_github.App.t -> unit -> service list
-
   val admins : string list
-
-  val v :
-    ?app:Current_github.App.t ->
-    ?notify:Current_slack.channel ->
-    ?filter:(Current_github.Repo_id.t -> bool) ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit -> unit Current.t
+  val v : pipeline
 end
 
 let docker ~sched { dockerfile; targets; archs; options } =

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -1,6 +1,12 @@
 (* Different Deployer pipelines available. *)
 module Flavour = struct
   type t = [`Tarides | `OCaml | `Mirage]
+
+  let to_string = function
+    | `Tarides -> "tarides"
+    | `OCaml -> "ocaml"
+    | `Mirage -> "mirage"
+
   let cmdliner =
     let open Cmdliner in
     let flavours = ["tarides", `Tarides

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -80,6 +80,19 @@ let build_kit (v : Cluster_api.Docker.Spec.options) = { v with buildkit = true }
 module Tarides = struct
   let base_url = Uri.of_string "https://deploy.ci.dev/"
 
+  let admins = [
+    "github:avsm";
+    "github:dra27";
+    "github:moyodiallo";
+    "github:MisterDA";
+    "github:mtelvers";
+    "github:punchagan";
+    "github:samoht";
+    "github:shonfeder";
+    "github:talex5";
+    "github:tmcgilchrist";
+  ]
+
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
@@ -325,6 +338,20 @@ end
 module Ocaml_org = struct
   let base_url = Uri.of_string "https://deploy.ci.ocaml.org"
 
+  let admins = [
+    "github:AltGr";
+    "github:avsm";
+    "github:dra27";
+    "github:moyodiallo";
+    "github:mtelvers";
+    "github:punchagan";
+    "github:rjbou";
+    "github:samoht";
+    "github:shonfeder";
+    "github:talex5";
+    "github:tmcgilchrist";
+  ]
+
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
@@ -511,7 +538,20 @@ module Ocaml_org = struct
 end
 
 module Mirage = struct
-  let base_url = Uri.of_string "https://deploy.mirage.io/" 
+  let base_url = Uri.of_string "https://deploy.mirage.io/"
+
+  let admins = [
+    "github:avsm";
+    "github:dra27";
+    "github:hannesm";
+    "github:moyodiallo";
+    "github:mtelvers";
+    "github:punchagan";
+    "github:samoht";
+    "github:shonfeder";
+    "github:talex5";
+    "github:tmcgilchrist";
+  ]
 
   let unikernel dockerfile ~target args services =
     let build_info = { Packet_unikernel.dockerfile; target; args } in

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -25,6 +25,8 @@ type service = Build.org * string * docker list
 module Tarides : sig
   val services : ?app:Current_github.App.t -> unit -> service list
 
+  val admins : string list
+
   val v :
     ?app:Current_github.App.t ->
     ?notify:Current_slack.channel ->
@@ -36,6 +38,8 @@ end
 
 module Ocaml_org : sig
   val services : ?app:Current_github.App.t -> unit -> service list
+
+  val admins : string list
 
   val v :
     ?app:Current_github.App.t ->
@@ -51,6 +55,8 @@ module Mirage : sig
     ?app:Current_github.App.t ->
     unit ->
     Packet_unikernel.service_info list
+
+  val admins : string list
 
   val docker_services : ?app:Current_github.App.t -> unit -> service list
 

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -24,20 +24,21 @@ type docker = {
 
 type service = Build.org * string * docker list
 
+type pipeline =
+  ?app:Current_github.App.t ->
+  ?notify:Current_slack.channel ->
+  ?filter:(Current_github.Repo_id.t -> bool) ->
+  sched:Current_ocluster.Connection.t ->
+  staging_auth:(string * string) option ->
+  unit ->
+  unit Current.t
+
 module type Constellation = sig
   (** The interface for a pipelines that can be deployed *)
 
   val services : ?app:Current_github.App.t -> unit -> service list
-
   val admins : string list
-
-  val v :
-    ?app:Current_github.App.t ->
-    ?notify:Current_slack.channel ->
-    ?filter:(Current_github.Repo_id.t -> bool) ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit -> unit Current.t
+  val v : pipeline
 end
 
 module Tarides : Constellation

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -1,14 +1,3 @@
-(* TODO: This sould not live in the pipeline *)
-(* Different deployer pipelines. *)
-module Flavour : sig
-  type t = [ `OCaml   (* for deploy.ci.ocaml.org *)
-           | `Tarides (* for deploy.ci3.ocamllabs.io *)
-           | `Mirage ] (* for deploy.mirage.io *)
-
-  val to_string : t -> string
-  val cmdliner : t Cmdliner.Term.t
-end
-
 type deployment = {
   branch : string;
   target : string;
@@ -32,15 +21,32 @@ type pipeline =
   staging_auth:(string * string) option ->
   unit ->
   unit Current.t
+(** A pipeline deploying a set of services *)
 
-module type Constellation = sig
-  (** The interface for a pipelines that can be deployed *)
+type deployer =
+  { pipeline: pipeline
+  (** A pipeline to deploy a set of {!service}. *)
+  ; admins: string list
+  (** The administrators for the deployer admins.*)
+  }
+
+module type Deployer = sig
+  (** A definition of a {!type:deployer}. *)
 
   val services : ?app:Current_github.App.t -> unit -> service list
-  val admins : string list
-  val v : pipeline
+  (** The list of services deployed *)
 end
 
-module Tarides : Constellation
-module Ocaml_org : Constellation
-module Mirage : Constellation
+module Tarides : Deployer
+(** Implementation of the deployer for Tarides services. *)
+
+module Ocaml_org : Deployer
+(** Implementation of the deployer for ocaml.org services. *)
+
+module Mirage : Deployer
+(** Implementation of the deployer for Mirage services. *)
+
+
+val cmdliner : deployer Cmdliner.Term.t
+(** [cmdliner] is a Cmdliner term that selects a {!type:deployer} pipelines
+    along with the list of admins for the selected pipeline *)

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -1,9 +1,11 @@
+(* TODO: This sould not live in the pipeline *)
 (* Different deployer pipelines. *)
 module Flavour : sig
   type t = [ `OCaml   (* for deploy.ci.ocaml.org *)
            | `Tarides (* for deploy.ci3.ocamllabs.io *)
            | `Mirage ] (* for deploy.mirage.io *)
 
+  val to_string : t -> string
   val cmdliner : t Cmdliner.Term.t
 end
 

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -22,7 +22,9 @@ type docker = {
 
 type service = Build.org * string * docker list
 
-module Tarides : sig
+module type Constellation = sig
+  (** The interface for a pipelines that can be deployed *)
+
   val services : ?app:Current_github.App.t -> unit -> service list
 
   val admins : string list
@@ -36,34 +38,6 @@ module Tarides : sig
     unit -> unit Current.t
 end
 
-module Ocaml_org : sig
-  val services : ?app:Current_github.App.t -> unit -> service list
-
-  val admins : string list
-
-  val v :
-    ?app:Current_github.App.t ->
-    ?notify:Current_slack.channel ->
-    ?filter:(Current_github.Repo_id.t -> bool) ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit -> unit Current.t
-end
-
-module Mirage : sig
-  val unikernel_services :
-    ?app:Current_github.App.t ->
-    unit ->
-    Packet_unikernel.service_info list
-
-  val admins : string list
-
-  val docker_services : ?app:Current_github.App.t -> unit -> service list
-
-  val v :
-    ?app:Current_github.App.t ->
-    ?notify:Current_slack.channel ->
-    sched:Current_ocluster.Connection.t ->
-    staging_auth:(string * string) option ->
-    unit -> unit Current.t
-end
+module Tarides : Constellation
+module Ocaml_org : Constellation
+module Mirage : Constellation

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -12,7 +12,25 @@ let test_simple () =
   Index.record ~repo ~hash [ ("build", Some "job2") ];
   Alcotest.(check (list string)) "Job-ids" ["job2"] @@ List.sort String.compare @@ Index.get_job_ids ~owner ~name ~hash
 
+let test_access_role () =
+  let case msg = Alcotest.(check' bool) ~msg in
+  let admins = ["Kenta"; "Hai"; "Jakob"] in
+  let has_role = Deployer.Access.user_has_role ~admins in
+  case "unauthenticated users SHOULD have view and monitor role"
+    ~expected:true
+    ~actual:(List.for_all (has_role None) [`Viewer; `Monitor]);
+  case "unauthenticated users MUST NOT have admin or builder role"
+    ~expected:false
+    ~actual:(List.for_all (has_role None) [`Admin; `Builder]);
+  case "non-admin users MUST NOT have admin or builder role"
+    ~expected:false
+    ~actual:(has_role (Some "Auden") `Admin || has_role (Some "Wenjing") `Builder);
+  case "admin users SHOULD have every role"
+    ~expected:true
+    ~actual:(List.for_all (has_role (Some "Kenta")) [`Viewer; `Monitor; `Builder; `Admin])
+
+
 let tests = [
     Alcotest_lwt.test_case_sync "simple" `Quick test_simple;
+    Alcotest_lwt.test_case_sync "access roles" `Quick test_access_role;
 ]
-


### PR DESCRIPTION
This is a prelude to https://github.com/tarides/infrastructure/issues/388 and to the (possible) future step of separating out the specific deployer configurations from the general purpose deployer library.

The commits explain the motivation for each changeset (which should be logically complete), tho there is some slight wandering evolution in the sequence of commits. The main outcomes are:

- The access control logic is moved to a single (tested) function.
- The "flavours" are re-conceived (internally) as "Deployers", satisfying a single (minimal) interface. 
- All logic and data that is specific to a particular deployer is moved into the respective module implementing the deployer. This allows us to reason about the entirety of a deployer's configuration locally, from within the implementing module, rather than having to keep in mind logic from the `main.ml` and `local.ml` executable logic as well.
- As a corollary, the `main.ml` and `local.ml` executabls no longer need to know anything about which deployers are defined how they are defines. 