### PR TITLE
Move opam-repo-ci to ocaml.org

### DIFF
--- a/doc/services.md
+++ b/doc/services.md
@@ -17,12 +17,6 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch [`live-www`](https://github.com/ocurrent/ocaml-ci/tree/live-www) built at [`ocurrent/ocaml-ci-web:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
   - branch [`staging-www`](https://github.com/ocurrent/ocaml-ci/tree/staging-www) built at [`ocurrent/ocaml-ci-web:staging`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
 
-### [ocurrent/opam-repo-ci](https://github.com/ocurrent/opam-repo-ci)
-- `Dockerfile` on arches: x86_64, arm64
-  - branch [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live) built at [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
-- `Dockerfile.web` on arches: x86_64, arm64
-  - branch [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web) built at [`ocurrent/opam-repo-ci-web:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci-web)
-
 ### [ocurrent/ocaml-multicore-ci](https://github.com/ocurrent/ocaml-multicore-ci)
 - `Dockerfile` on arches: x86_64
   - branch [`live`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live) built at [`ocurrent/multicore-ci:live`](https://hub.docker.com/r/ocurrent/multicore-ci)
@@ -74,6 +68,12 @@ For a given service, the specified Dockerfile is pulled from the specified branc
 ### [ocurrent/opam-health-check](https://github.com/ocurrent/opam-health-check)
 - `Dockerfile` on arches: x86_64
   - branch [`live`](https://github.com/ocurrent/opam-health-check/tree/live) built at [`ocurrent/opam-health-check:live`](https://hub.docker.com/r/ocurrent/opam-health-check)
+
+### [ocurrent/opam-repo-ci](https://github.com/ocurrent/opam-repo-ci)
+- `Dockerfile` on arches: x86_64, arm64
+  - branch [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live) built at [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
+- `Dockerfile.web` on arches: x86_64, arm64
+  - branch [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web) built at [`ocurrent/opam-repo-ci-web:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci-web)
 
 ## Mirage Docker services
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -189,26 +189,6 @@ module Tarides = struct
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64] ~options:include_git;
       ];
-      ocurrent, "opam-repo-ci", [
-        make_docker
-          "Dockerfile"
-          [
-            make_deployment
-              ~branch:"live"
-              ~target:"ocurrent/opam-repo-ci:live"
-              [`Opamrepo "opam-repo-ci_opam-repo-ci"];
-          ]
-          ~archs:[`Linux_x86_64; `Linux_arm64];
-        make_docker
-          "Dockerfile.web"
-          [
-            make_deployment
-              ~branch:"live-web"
-              ~target:"ocurrent/opam-repo-ci-web:live"
-              [`Opamrepo "opam-repo-ci_opam-repo-ci-web"];
-          ]
-          ~archs:[`Linux_x86_64; `Linux_arm64];
-      ];
       ocurrent, "ocaml-multicore-ci", [
         make_docker
           "Dockerfile"
@@ -457,6 +437,26 @@ module Ocaml_org = struct
               ~target:"ocurrent/opam-health-check:live"
               [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"];
           ];
+      ];
+      ocurrent, "opam-repo-ci", [
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              ~branch:"live"
+              ~target:"ocurrent/opam-repo-ci:live"
+              [`Opamrepo "opam-repo-ci_opam-repo-ci"];
+          ]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
+        make_docker
+          "Dockerfile.web"
+          [
+            make_deployment
+              ~branch:"live-web"
+              ~target:"ocurrent/opam-repo-ci-web:live"
+              [`Opamrepo "opam-repo-ci_opam-repo-ci-web"];
+          ]
+          ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
     ]
 


### PR DESCRIPTION
Closes https://github.com/tarides/infrastructure/issues/388

With this change, I think we now have all of the indicated services grouped
correctly (i.e. all "Ecosystem services" under the ocaml.org deployer), with the
exception of https://github.com/ocurrent/current-bench. The latter has been
indicated as belonging in this group, but it is not currently handled by the
deployer.