### PR TITLE
Refactor to remove abstraction leak into `cluster.ml`

### DIFF
--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -24,12 +24,12 @@ let show_docker_hub_link tag =
 
 let show_services services =
   services
-  |> List.map (fun ({name; docker_context} : Cluster.service) ->
-      let context = match docker_context with
+  |> List.map (fun ({name; docker_context = _; uri} : Cluster.service) ->
+      let uri = match uri with
         | None -> ""
-        | Some c -> Printf.sprintf (" @ <https://%s>") c
+        | Some uri -> Printf.sprintf (" @ <https://%s>") uri
       in
-      Printf.sprintf "    - `%s`%s" name  context
+      Printf.sprintf "    - `%s`%s" name uri
     )
   |> String.concat "\n"
 

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -22,6 +22,17 @@ let show_docker_hub_link tag =
   | None -> Printf.sprintf "`%s`" tag
   | Some url -> Printf.sprintf "[`%s`](%s)" tag url
 
+let show_services services =
+  services
+  |> List.map (fun ({name; docker_context} : Cluster.service) ->
+      let context = match docker_context with
+        | None -> ""
+        | Some c -> Printf.sprintf (" @ <https://%s>") c
+      in
+      Printf.sprintf "    - `%s`%s" name  context
+    )
+  |> String.concat "\n"
+
 let show_docker ~org ~name t =
   if not (has_deployments t) then []
   else
@@ -32,10 +43,11 @@ let show_docker ~org ~name t =
       List.map
         (fun t ->
           Printf.sprintf
-            "  - branch [`%s`](%s) built at %s"
+            "  - branch: [`%s`](%s)\n  - registered image: %s\n  - services:\n%s\n"
             t.Pipeline.branch
             (show_github_link ~org ~name t.branch)
-            (show_docker_hub_link t.target))
+            (show_docker_hub_link t.target)
+            (show_services t.services))
         t.targets
     in
     header :: deployments
@@ -44,7 +56,7 @@ let show_service (org, name, dockers) =
   if not @@ List.exists has_deployments dockers then None
   else
     let org = Build.account org in
-    let header = [ Printf.sprintf "### [%s/%s](https://github.com/%s/%s)" org name org name ] in
+    let header = [ Printf.sprintf "### [%s/%s](https://github.com/%s/%s)\n" org name org name ] in
     let dockers =
       List.map (show_docker ~org ~name) dockers
       |> List.flatten
@@ -54,11 +66,11 @@ let show_service (org, name, dockers) =
 let () =
   Printf.printf "# Deployed CI services\n\n";
   Printf.printf "For a given service, the specified Dockerfile is pulled from the specified branch and built to produce an image, which is then pushed to Docker Hub with the specified tag.\n\n";
-  let f label services =
-    Printf.printf "## %s\n\n" label;
+  let f label deployer_url services =
+    Printf.printf "## %s\n<%s>\n\n" label (Uri.to_string deployer_url);
     List.filter_map show_service services
     |> List.iter (Printf.printf "%s\n\n")
   in
-  f "Tarides services" @@ Pipeline.Tarides.services ();
-  f "OCaml Org services" @@ Pipeline.Ocaml_org.services ();
-  f "Mirage Docker services" @@ Pipeline.Mirage.services ()
+  f "Tarides services" Pipeline.Tarides.base_url @@ Pipeline.Tarides.services ();
+  f "OCaml Org services" Pipeline.Ocaml_org.base_url @@ Pipeline.Ocaml_org.services ();
+  f "Mirage Docker services" Pipeline.Mirage.base_url @@ Pipeline.Mirage.services ()

--- a/doc/services.md
+++ b/doc/services.md
@@ -192,7 +192,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
 
 
 ## Mirage Docker services
-<https://deploy.mirage.io/>
+<https://deploy.mirageos.org/>
 
 ### [ocurrent/mirage-ci](https://github.com/ocurrent/mirage-ci)
 
@@ -200,16 +200,16 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/mirage-ci/tree/live)
   - registered image: [`ocurrent/mirage-ci:live`](https://hub.docker.com/r/ocurrent/mirage-ci)
   - services:
-    - `infra_mirage-ci` @ <https://ci.mirage.io>
+    - `infra_mirage-ci` @ <https://ci.mirageos.org>
 
 
 ### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
 
 - `Dockerfile` on arches: x86_64
   - branch: [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage)
-  - registered image: [`ocurrent/deploy.mirage.io:live`](https://hub.docker.com/r/ocurrent/deploy.mirage.io)
+  - registered image: [`ocurrent/deploy.mirageos.org:live`](https://hub.docker.com/r/ocurrent/deploy.mirageos.org)
   - services:
-    - `infra_deployer` @ <https://ci.mirage.io>
+    - `infra_deployer` @ <https://ci.mirageos.org>
 
 
 ### [ocurrent/caddy-rfc2136](https://github.com/ocurrent/caddy-rfc2136)
@@ -218,6 +218,6 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`master`](https://github.com/ocurrent/caddy-rfc2136/tree/master)
   - registered image: [`ocurrent/caddy-rfc2136:live`](https://hub.docker.com/r/ocurrent/caddy-rfc2136)
   - services:
-    - `infra_caddy` @ <https://ci.mirage.io>
+    - `infra_caddy` @ <https://ci.mirageos.org>
 
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -11,7 +11,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live-ci3`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ci3)
   - registered image: [`ocurrent/ci.ocamllabs.io-deployer:live-ci3`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
   - services:
-    - `deployer_deployer`
+    - `deployer_deployer` @ <https://deploy.ci.dev>
 
 
 ### [ocurrent/ocaml-ci](https://github.com/ocurrent/ocaml-ci)
@@ -20,13 +20,13 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine)
   - registered image: [`ocurrent/ocaml-ci-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-service)
   - services:
-    - `ocaml-ci_ci` @ <https://ocaml.ci.dev>
+    - `ocaml-ci_ci` @ <https://ocaml.ci.dev:8100>
 
 - `Dockerfile.gitlab` on arches: x86_64, arm64
   - branch: [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine)
   - registered image: [`ocurrent/ocaml-ci-gitlab-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-gitlab-service)
   - services:
-    - `ocaml-ci_gitlab` @ <https://ocaml.ci.dev>
+    - `ocaml-ci_gitlab` @ <https://ocaml.ci.dev:8200>
 
 - `Dockerfile.web` on arches: x86_64, arm64
   - branch: [`live-www`](https://github.com/ocurrent/ocaml-ci/tree/live-www)
@@ -37,7 +37,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`staging-www`](https://github.com/ocurrent/ocaml-ci/tree/staging-www)
   - registered image: [`ocurrent/ocaml-ci-web:staging`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
   - services:
-    - `test-www` @ <https://ocaml.ci.dev>
+    - `test-www`
 
 
 ### [ocurrent/ocaml-multicore-ci](https://github.com/ocurrent/ocaml-multicore-ci)
@@ -46,13 +46,13 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live)
   - registered image: [`ocurrent/multicore-ci:live`](https://hub.docker.com/r/ocurrent/multicore-ci)
   - services:
-    - `infra_multicore-ci` @ <https://ci4.ocamllabs.io>
+    - `infra_multicore-ci` @ <https://ocaml-multicore.ci.dev:8100>
 
 - `Dockerfile.web` on arches: x86_64
   - branch: [`live-web`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live-web)
   - registered image: [`ocurrent/multicore-ci-web:live`](https://hub.docker.com/r/ocurrent/multicore-ci-web)
   - services:
-    - `infra_multicore-ci-web` @ <https://ci4.ocamllabs.io>
+    - `infra_multicore-ci-web` @ <https://ocaml-multicore.ci.dev>
 
 
 ### [ocurrent/ocurrent.org](https://github.com/ocurrent/ocurrent.org)
@@ -61,7 +61,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live-engine`](https://github.com/ocurrent/ocurrent.org/tree/live-engine)
   - registered image: [`ocurrent/ocurrent.org:live-engine`](https://hub.docker.com/r/ocurrent/ocurrent.org)
   - services:
-    - `ocurrent_org_watcher` @ <https://ci3.ocamllabs.io>
+    - `ocurrent_org_watcher` @ <https://watcher.ci.dev>
 
 
 ### [ocaml-bench/sandmark-nightly](https://github.com/ocaml-bench/sandmark-nightly)
@@ -70,7 +70,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`main`](https://github.com/ocaml-bench/sandmark-nightly/tree/main)
   - registered image: [`ocurrent/sandmark-nightly:live`](https://hub.docker.com/r/ocurrent/sandmark-nightly)
   - services:
-    - `sandmark_sandmark` @ <https://ci3.ocamllabs.io>
+    - `sandmark_sandmark` @ <https://sandmark.tarides.com>
 
 
 ### [ocurrent/multicoretests-ci](https://github.com/ocurrent/multicoretests-ci)
@@ -79,7 +79,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/multicoretests-ci/tree/live)
   - registered image: [`ocurrent/multicoretests-ci:live`](https://hub.docker.com/r/ocurrent/multicoretests-ci)
   - services:
-    - `infra_multicoretests-ci` @ <https://ci4.ocamllabs.io>
+    - `infra_multicoretests-ci` @ <https://ocaml-multicoretests.ci.dev:8100>
 
 
 ## OCaml Org services
@@ -91,7 +91,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live-ocaml-org`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ocaml-org)
   - registered image: [`ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
   - services:
-    - `infra_deployer`
+    - `infra_deployer` @ <https://deploy.ci.ocaml.org>
 
 
 ### [ocaml/ocaml.org](https://github.com/ocaml/ocaml.org)
@@ -100,13 +100,13 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`main`](https://github.com/ocaml/ocaml.org/tree/main)
   - registered image: [`ocurrent/v3.ocaml.org-server:live`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
   - services:
-    - `infra_www` @ <https://v3b.ocaml.org>
+    - `infra_www` @ <https://ocaml.org>
 
 - `Dockerfile` on arches: x86_64
   - branch: [`staging`](https://github.com/ocaml/ocaml.org/tree/staging)
   - registered image: [`ocurrent/v3.ocaml.org-server:staging`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
   - services:
-    - `infra_www` @ <https://v3c.ocaml.org>
+    - `infra_www` @ <https://staging.ocaml.org>
 
 
 ### [ocurrent/docker-base-images](https://github.com/ocurrent/docker-base-images)
@@ -115,7 +115,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/docker-base-images/tree/live)
   - registered image: [`ocurrent/base-images:live`](https://hub.docker.com/r/ocurrent/base-images)
   - services:
-    - `base-images_builder` @ <https://v3c.ocaml.org>
+    - `base-images_builder` @ <https://images.ci.ocaml.org>
 
 
 ### [ocurrent/ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci)
@@ -130,31 +130,31 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live)
   - registered image: [`ocurrent/docs-ci-init:live`](https://hub.docker.com/r/ocurrent/docs-ci-init)
   - services:
-    - `infra_init` @ <https://docs.ci.ocaml.org>
+    - `infra_init`
 
 - `docker/storage/Dockerfile` on arches: x86_64
   - branch: [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live)
   - registered image: [`ocurrent/docs-ci-storage-server:live`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
   - services:
-    - `infra_storage-server` @ <https://docs.ci.ocaml.org>
+    - `infra_storage-server`
 
 - `Dockerfile` on arches: x86_64
   - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
   - registered image: [`ocurrent/docs-ci:staging`](https://hub.docker.com/r/ocurrent/docs-ci)
   - services:
-    - `infra_docs-ci` @ <https://staging.docs.ci.ocaml.org>
+    - `infra_docs-ci` @ <https://staging.docs.ci.ocamllabs.io>
 
 - `docker/init/Dockerfile` on arches: x86_64
   - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
   - registered image: [`ocurrent/docs-ci-init:staging`](https://hub.docker.com/r/ocurrent/docs-ci-init)
   - services:
-    - `infra_init` @ <https://staging.docs.ci.ocaml.org>
+    - `infra_init`
 
 - `docker/storage/Dockerfile` on arches: x86_64
   - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
   - registered image: [`ocurrent/docs-ci-storage-server:staging`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
   - services:
-    - `infra_storage-server` @ <https://staging.docs.ci.ocaml.org>
+    - `infra_storage-server`
 
 
 ### [ocurrent/opam-health-check](https://github.com/ocurrent/opam-health-check)
@@ -164,7 +164,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - registered image: [`ocurrent/opam-health-check:live`](https://hub.docker.com/r/ocurrent/opam-health-check)
   - services:
     - `infra_opam-health-check` @ <https://check.ci.ocaml.org>
-    - `infra_opam-health-check-freebsd` @ <https://check.ci.ocaml.org>
+    - `infra_opam-health-check-freebsd` @ <https://freebsd.check.ci.dev>
 
 
 ### [ocurrent/opam-repo-ci](https://github.com/ocurrent/opam-repo-ci)
@@ -173,7 +173,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live)
   - registered image: [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
   - services:
-    - `opam-repo-ci_opam-repo-ci` @ <https://opam.ci.ocaml.org>
+    - `opam-repo-ci_opam-repo-ci` @ <https://opam-repo.ci.ocaml.org>
 
 - `Dockerfile.web` on arches: x86_64, arm64
   - branch: [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web)
@@ -209,7 +209,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage)
   - registered image: [`ocurrent/deploy.mirageos.org:live`](https://hub.docker.com/r/ocurrent/deploy.mirageos.org)
   - services:
-    - `infra_deployer` @ <https://ci.mirageos.org>
+    - `infra_deployer` @ <https://deploy.mirageos.org>
 
 
 ### [ocurrent/caddy-rfc2136](https://github.com/ocurrent/caddy-rfc2136)
@@ -218,6 +218,6 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`master`](https://github.com/ocurrent/caddy-rfc2136/tree/master)
   - registered image: [`ocurrent/caddy-rfc2136:live`](https://hub.docker.com/r/ocurrent/caddy-rfc2136)
   - services:
-    - `infra_caddy` @ <https://ci.mirageos.org>
+    - `infra_caddy`
 
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -3,93 +3,216 @@
 For a given service, the specified Dockerfile is pulled from the specified branch and built to produce an image, which is then pushed to Docker Hub with the specified tag.
 
 ## Tarides services
+<https://deploy.ci.dev/>
 
 ### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live-ci3`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ci3) built at [`ocurrent/ci.ocamllabs.io-deployer:live-ci3`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+  - branch: [`live-ci3`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ci3)
+  - registered image: [`ocurrent/ci.ocamllabs.io-deployer:live-ci3`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+  - services:
+    - `deployer_deployer`
+
 
 ### [ocurrent/ocaml-ci](https://github.com/ocurrent/ocaml-ci)
+
 - `Dockerfile` on arches: x86_64, arm64
-  - branch [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine) built at [`ocurrent/ocaml-ci-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-service)
+  - branch: [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine)
+  - registered image: [`ocurrent/ocaml-ci-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-service)
+  - services:
+    - `ocaml-ci_ci` @ <https://ocaml.ci.dev>
+
 - `Dockerfile.gitlab` on arches: x86_64, arm64
-  - branch [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine) built at [`ocurrent/ocaml-ci-gitlab-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-gitlab-service)
+  - branch: [`live-engine`](https://github.com/ocurrent/ocaml-ci/tree/live-engine)
+  - registered image: [`ocurrent/ocaml-ci-gitlab-service:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-gitlab-service)
+  - services:
+    - `ocaml-ci_gitlab` @ <https://ocaml.ci.dev>
+
 - `Dockerfile.web` on arches: x86_64, arm64
-  - branch [`live-www`](https://github.com/ocurrent/ocaml-ci/tree/live-www) built at [`ocurrent/ocaml-ci-web:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
-  - branch [`staging-www`](https://github.com/ocurrent/ocaml-ci/tree/staging-www) built at [`ocurrent/ocaml-ci-web:staging`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
+  - branch: [`live-www`](https://github.com/ocurrent/ocaml-ci/tree/live-www)
+  - registered image: [`ocurrent/ocaml-ci-web:live`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
+  - services:
+    - `ocaml-ci_web` @ <https://ocaml.ci.dev>
+
+  - branch: [`staging-www`](https://github.com/ocurrent/ocaml-ci/tree/staging-www)
+  - registered image: [`ocurrent/ocaml-ci-web:staging`](https://hub.docker.com/r/ocurrent/ocaml-ci-web)
+  - services:
+    - `test-www` @ <https://ocaml.ci.dev>
+
 
 ### [ocurrent/ocaml-multicore-ci](https://github.com/ocurrent/ocaml-multicore-ci)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live) built at [`ocurrent/multicore-ci:live`](https://hub.docker.com/r/ocurrent/multicore-ci)
+  - branch: [`live`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live)
+  - registered image: [`ocurrent/multicore-ci:live`](https://hub.docker.com/r/ocurrent/multicore-ci)
+  - services:
+    - `infra_multicore-ci` @ <https://ci4.ocamllabs.io>
+
 - `Dockerfile.web` on arches: x86_64
-  - branch [`live-web`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live-web) built at [`ocurrent/multicore-ci-web:live`](https://hub.docker.com/r/ocurrent/multicore-ci-web)
+  - branch: [`live-web`](https://github.com/ocurrent/ocaml-multicore-ci/tree/live-web)
+  - registered image: [`ocurrent/multicore-ci-web:live`](https://hub.docker.com/r/ocurrent/multicore-ci-web)
+  - services:
+    - `infra_multicore-ci-web` @ <https://ci4.ocamllabs.io>
+
 
 ### [ocurrent/ocurrent.org](https://github.com/ocurrent/ocurrent.org)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live-engine`](https://github.com/ocurrent/ocurrent.org/tree/live-engine) built at [`ocurrent/ocurrent.org:live-engine`](https://hub.docker.com/r/ocurrent/ocurrent.org)
+  - branch: [`live-engine`](https://github.com/ocurrent/ocurrent.org/tree/live-engine)
+  - registered image: [`ocurrent/ocurrent.org:live-engine`](https://hub.docker.com/r/ocurrent/ocurrent.org)
+  - services:
+    - `ocurrent_org_watcher` @ <https://ci3.ocamllabs.io>
+
 
 ### [ocaml-bench/sandmark-nightly](https://github.com/ocaml-bench/sandmark-nightly)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`main`](https://github.com/ocaml-bench/sandmark-nightly/tree/main) built at [`ocurrent/sandmark-nightly:live`](https://hub.docker.com/r/ocurrent/sandmark-nightly)
+  - branch: [`main`](https://github.com/ocaml-bench/sandmark-nightly/tree/main)
+  - registered image: [`ocurrent/sandmark-nightly:live`](https://hub.docker.com/r/ocurrent/sandmark-nightly)
+  - services:
+    - `sandmark_sandmark` @ <https://ci3.ocamllabs.io>
+
 
 ### [ocurrent/multicoretests-ci](https://github.com/ocurrent/multicoretests-ci)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/multicoretests-ci/tree/live) built at [`ocurrent/multicoretests-ci:live`](https://hub.docker.com/r/ocurrent/multicoretests-ci)
+  - branch: [`live`](https://github.com/ocurrent/multicoretests-ci/tree/live)
+  - registered image: [`ocurrent/multicoretests-ci:live`](https://hub.docker.com/r/ocurrent/multicoretests-ci)
+  - services:
+    - `infra_multicoretests-ci` @ <https://ci4.ocamllabs.io>
+
 
 ## OCaml Org services
+<https://deploy.ci.ocaml.org>
 
 ### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live-ocaml-org`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ocaml-org) built at [`ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+  - branch: [`live-ocaml-org`](https://github.com/ocurrent/ocurrent-deployer/tree/live-ocaml-org)
+  - registered image: [`ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org`](https://hub.docker.com/r/ocurrent/ci.ocamllabs.io-deployer)
+  - services:
+    - `infra_deployer`
+
 
 ### [ocaml/ocaml.org](https://github.com/ocaml/ocaml.org)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`main`](https://github.com/ocaml/ocaml.org/tree/main) built at [`ocurrent/v3.ocaml.org-server:live`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+  - branch: [`main`](https://github.com/ocaml/ocaml.org/tree/main)
+  - registered image: [`ocurrent/v3.ocaml.org-server:live`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+  - services:
+    - `infra_www` @ <https://v3b.ocaml.org>
+
 - `Dockerfile` on arches: x86_64
-  - branch [`staging`](https://github.com/ocaml/ocaml.org/tree/staging) built at [`ocurrent/v3.ocaml.org-server:staging`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+  - branch: [`staging`](https://github.com/ocaml/ocaml.org/tree/staging)
+  - registered image: [`ocurrent/v3.ocaml.org-server:staging`](https://hub.docker.com/r/ocurrent/v3.ocaml.org-server)
+  - services:
+    - `infra_www` @ <https://v3c.ocaml.org>
+
 
 ### [ocurrent/docker-base-images](https://github.com/ocurrent/docker-base-images)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/docker-base-images/tree/live) built at [`ocurrent/base-images:live`](https://hub.docker.com/r/ocurrent/base-images)
+  - branch: [`live`](https://github.com/ocurrent/docker-base-images/tree/live)
+  - registered image: [`ocurrent/base-images:live`](https://hub.docker.com/r/ocurrent/base-images)
+  - services:
+    - `base-images_builder` @ <https://v3c.ocaml.org>
+
 
 ### [ocurrent/ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci:live`](https://hub.docker.com/r/ocurrent/docs-ci)
+  - branch: [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live)
+  - registered image: [`ocurrent/docs-ci:live`](https://hub.docker.com/r/ocurrent/docs-ci)
+  - services:
+    - `infra_docs-ci` @ <https://docs.ci.ocaml.org>
+
 - `docker/init/Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci-init:live`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+  - branch: [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live)
+  - registered image: [`ocurrent/docs-ci-init:live`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+  - services:
+    - `infra_init` @ <https://docs.ci.ocaml.org>
+
 - `docker/storage/Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live) built at [`ocurrent/docs-ci-storage-server:live`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+  - branch: [`live`](https://github.com/ocurrent/ocaml-docs-ci/tree/live)
+  - registered image: [`ocurrent/docs-ci-storage-server:live`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+  - services:
+    - `infra_storage-server` @ <https://docs.ci.ocaml.org>
+
 - `Dockerfile` on arches: x86_64
-  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci:staging`](https://hub.docker.com/r/ocurrent/docs-ci)
+  - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
+  - registered image: [`ocurrent/docs-ci:staging`](https://hub.docker.com/r/ocurrent/docs-ci)
+  - services:
+    - `infra_docs-ci` @ <https://staging.docs.ci.ocaml.org>
+
 - `docker/init/Dockerfile` on arches: x86_64
-  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci-init:staging`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+  - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
+  - registered image: [`ocurrent/docs-ci-init:staging`](https://hub.docker.com/r/ocurrent/docs-ci-init)
+  - services:
+    - `infra_init` @ <https://staging.docs.ci.ocaml.org>
+
 - `docker/storage/Dockerfile` on arches: x86_64
-  - branch [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging) built at [`ocurrent/docs-ci-storage-server:staging`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+  - branch: [`staging`](https://github.com/ocurrent/ocaml-docs-ci/tree/staging)
+  - registered image: [`ocurrent/docs-ci-storage-server:staging`](https://hub.docker.com/r/ocurrent/docs-ci-storage-server)
+  - services:
+    - `infra_storage-server` @ <https://staging.docs.ci.ocaml.org>
+
 
 ### [ocurrent/opam-health-check](https://github.com/ocurrent/opam-health-check)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/opam-health-check/tree/live) built at [`ocurrent/opam-health-check:live`](https://hub.docker.com/r/ocurrent/opam-health-check)
+  - branch: [`live`](https://github.com/ocurrent/opam-health-check/tree/live)
+  - registered image: [`ocurrent/opam-health-check:live`](https://hub.docker.com/r/ocurrent/opam-health-check)
+  - services:
+    - `infra_opam-health-check` @ <https://check.ci.ocaml.org>
+    - `infra_opam-health-check-freebsd` @ <https://check.ci.ocaml.org>
+
 
 ### [ocurrent/opam-repo-ci](https://github.com/ocurrent/opam-repo-ci)
+
 - `Dockerfile` on arches: x86_64, arm64
-  - branch [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live) built at [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
+  - branch: [`live`](https://github.com/ocurrent/opam-repo-ci/tree/live)
+  - registered image: [`ocurrent/opam-repo-ci:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci)
+  - services:
+    - `opam-repo-ci_opam-repo-ci` @ <https://opam.ci.ocaml.org>
+
 - `Dockerfile.web` on arches: x86_64, arm64
-  - branch [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web) built at [`ocurrent/opam-repo-ci-web:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci-web)
+  - branch: [`live-web`](https://github.com/ocurrent/opam-repo-ci/tree/live-web)
+  - registered image: [`ocurrent/opam-repo-ci-web:live`](https://hub.docker.com/r/ocurrent/opam-repo-ci-web)
+  - services:
+    - `opam-repo-ci_opam-repo-ci-web` @ <https://opam.ci.ocaml.org>
+
 
 ### [ocaml-dune/binary-distribution](https://github.com/ocaml-dune/binary-distribution)
 - `Dockerfile` on arches: x86_64
   - branch [`main`](https://github.com/ocaml-dune/binary-distribution/tree/main) built at [`ocurrent/dune-binary-distribution:live`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
 
 ## Mirage Docker services
+<https://deploy.mirage.io/>
 
 ### [ocurrent/mirage-ci](https://github.com/ocurrent/mirage-ci)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live`](https://github.com/ocurrent/mirage-ci/tree/live) built at [`ocurrent/mirage-ci:live`](https://hub.docker.com/r/ocurrent/mirage-ci)
+  - branch: [`live`](https://github.com/ocurrent/mirage-ci/tree/live)
+  - registered image: [`ocurrent/mirage-ci:live`](https://hub.docker.com/r/ocurrent/mirage-ci)
+  - services:
+    - `infra_mirage-ci` @ <https://ci.mirage.io>
+
 
 ### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage) built at [`ocurrent/deploy.mirageos.org:live`](https://hub.docker.com/r/ocurrent/deploy.mirageos.org)
+  - branch: [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage)
+  - registered image: [`ocurrent/deploy.mirage.io:live`](https://hub.docker.com/r/ocurrent/deploy.mirage.io)
+  - services:
+    - `infra_deployer` @ <https://ci.mirage.io>
+
 
 ### [ocurrent/caddy-rfc2136](https://github.com/ocurrent/caddy-rfc2136)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`master`](https://github.com/ocurrent/caddy-rfc2136/tree/master) built at [`ocurrent/caddy-rfc2136:live`](https://hub.docker.com/r/ocurrent/caddy-rfc2136)
+  - branch: [`master`](https://github.com/ocurrent/caddy-rfc2136/tree/master)
+  - registered image: [`ocurrent/caddy-rfc2136:live`](https://hub.docker.com/r/ocurrent/caddy-rfc2136)
+  - services:
+    - `infra_caddy` @ <https://ci.mirage.io>
+
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -183,8 +183,13 @@ For a given service, the specified Dockerfile is pulled from the specified branc
 
 
 ### [ocaml-dune/binary-distribution](https://github.com/ocaml-dune/binary-distribution)
+
 - `Dockerfile` on arches: x86_64
-  - branch [`main`](https://github.com/ocaml-dune/binary-distribution/tree/main) built at [`ocurrent/dune-binary-distribution:live`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
+  - branch: [`main`](https://github.com/ocaml-dune/binary-distribution/tree/main)
+  - registered image: [`ocurrent/dune-binary-distribution:live`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
+  - services:
+    - `infra_www` @ <https://get.dune.build>
+
 
 ## Mirage Docker services
 <https://deploy.mirage.io/>

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -69,8 +69,6 @@ type service = [
   | `Ocamlorg_images of string               (* Base Image builder @ images.ci.ocaml.org *)
   | `OCamlorg_v3b of string                  (* OCaml website @ v3b.ocaml.org aka www.ocaml.org *)
   | `OCamlorg_v3c of string                  (* Staging OCaml website @ staging.ocaml.org *)
-  | `Dune_binary_distribution of string      (* Dune binary distribution website *)
-  | `Aws_ecs of Aws.t                        (* Amazon Web Services - Elastic Container Service *)
 ] [@@deriving show]
 
 type deploy_info = {
@@ -184,10 +182,6 @@ let pull_and_serve multi_hash = function
   | `Ocamlorg_images name -> pull_and_serve (module Ocamlorg_images) ~name `Service multi_hash
   | `OCamlorg_v3b name -> pull_and_serve (module V3b_docker) ~name `Service multi_hash
   | `OCamlorg_v3c name -> pull_and_serve (module V3c_docker) ~name `Service multi_hash
-  | `Dune_binary_distribution name -> pull_and_serve (module Dune_binary_docker) ~name `Service multi_hash
-  | `Aws_ecs project ->
-    let contents = Aws.compose project in
-    pull_and_serve (module Docker_aws) ~name:(project.name ^ "-" ^ project.branch) (`Compose_cli contents) multi_hash
 
 let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(additional_build_args=Current.return []) src =
   let src = Current.map (fun x -> [x]) src in

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -107,11 +107,6 @@ let name info = Cluster_api.Docker.Image_id.to_string info.hub_id
 
 let no_schedule = Current_cache.Schedule.v ()
 
-let docker_module context : (module Current_docker.S.DOCKER) =
-  match context with
-  | None -> (module Current_docker.Default)
-  | Some _ -> (module Current_docker.Make(struct let docker_context = context end))
-
 let pull_and_serve op repo_id {docker_context; name; _} =
   let module D = (val docker_context) in
   let image =

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -35,7 +35,8 @@ type build_info = {
 
 type service = {
   name : string;
-  docker_context : string option;
+  docker_context : (module Current_docker.S.DOCKER);
+  uri : string option;
 }
 
 type deploy_info = {
@@ -111,8 +112,8 @@ let docker_module context : (module Current_docker.S.DOCKER) =
   | None -> (module Current_docker.Default)
   | Some _ -> (module Current_docker.Make(struct let docker_context = context end))
 
-let pull_and_serve op repo_id {docker_context; name} =
-  let module D = (val docker_module docker_context) in
+let pull_and_serve op repo_id {docker_context; name; _} =
+  let module D = (val docker_context) in
   let image =
     Current.component "pull" |>
     let> repo_id in

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -26,24 +26,6 @@ end
 
 let push_repo = "ocurrentbuilder/staging"
 
-(* Strings here represent the docker context to use. *)
-module Ci3_docker = Current_docker.Default
-module Ci4_docker = Current_docker.Make(struct let docker_context = Some "ci4.ocamllabs.io" end)
-module Docs_docker = Current_docker.Make(struct let docker_context = Some "docs.ci.ocaml.org" end)
-module Staging_docs_docker = Current_docker.Make(struct let docker_context = Some "staging.docs.ci.ocamllabs.io" end)
-module Ci_docker = Current_docker.Make(struct let docker_context = Some "ocaml.ci.dev" end)
-module Opamrepo_docker = Current_docker.Make(struct let docker_context = Some "opam.ci.ocaml.org" end)
-module Check_docker = Current_docker.Make(struct let docker_context = Some "check.ci.ocaml.org" end)
-module Watch_docker = Current_docker.Make(struct let docker_context = Some "watch.ocaml.org" end)
-module Ocamlorg_docker = Current_docker.Make(struct let docker_context = Some "ocaml-www1" end)
-module Cimirage_docker = Current_docker.Make(struct let docker_context = Some "ci.mirageos.org" end)
-module Ocamlorg_images = Current_docker.Make(struct let docker_context = Some "ci3.ocamllabs.io" end)
-module Docker_aws = Current_docker.Make(struct let docker_context = Some "awsecs" end)
-module V3b_docker = Current_docker.Make(struct let docker_context = Some "v3b.ocaml.org" end)
-module V3c_docker = Current_docker.Make(struct let docker_context = Some "v3c.ocaml.org" end)
-module Dune_binary_docker = Current_docker.Make(struct let docker_context = Some "get.dune.build" end)
-module Deploycamlorg_docker = Current_docker.Default
-
 type build_info = {
   sched : Current_ocluster.t;
   dockerfile : [`Contents of string Current.t | `Path of string];
@@ -51,25 +33,10 @@ type build_info = {
   archs : Arch.t list;
 }
 
-type service = [
-(* Services on deploy.ci.dev *)
-  | `Ci of string
-  | `Opamrepo of string
-  | `Check of string
-  | `Ci3 of string
-  | `Ci4 of string
-  | `Docs of string
-  | `Staging_docs of string
-
-  (* Services on deploy.mirageos.org *)
-  | `Cimirage of string
-
-  (* Services on deploy.ci.ocaml.org. *)
-  | `Ocamlorg_deployer of string             (* OCurrent deployer @ deploy.ci.ocaml.org *)
-  | `Ocamlorg_images of string               (* Base Image builder @ images.ci.ocaml.org *)
-  | `OCamlorg_v3b of string                  (* OCaml website @ v3b.ocaml.org aka www.ocaml.org *)
-  | `OCamlorg_v3c of string                  (* Staging OCaml website @ staging.ocaml.org *)
-] [@@deriving show]
+type service = {
+  name : string;
+  docker_context : string option;
+}
 
 type deploy_info = {
   hub_id : Cluster_api.Docker.Image_id.t;
@@ -139,7 +106,13 @@ let name info = Cluster_api.Docker.Image_id.to_string info.hub_id
 
 let no_schedule = Current_cache.Schedule.v ()
 
-let pull_and_serve (module D : Current_docker.S.DOCKER) ~name op repo_id =
+let docker_module context : (module Current_docker.S.DOCKER) =
+  match context with
+  | None -> (module Current_docker.Default)
+  | Some _ -> (module Current_docker.Make(struct let docker_context = context end))
+
+let pull_and_serve op repo_id {docker_context; name} =
+  let module D = (val docker_module docker_context) in
   let image =
     Current.component "pull" |>
     let> repo_id in
@@ -166,23 +139,6 @@ let build_and_push ?level ?label ?cache_hint t ~push_target ~pool ~src ~options 
   and> src in
   Current_ocluster.Raw.build_and_push ?level ?cache_hint t ~push_target ~pool ~src ~options dockerfile
 
-let pull_and_serve multi_hash = function
-  (* deploy.ci.dev *)
-  | `Ci3 name -> pull_and_serve (module Ci3_docker) ~name `Service multi_hash
-  | `Ci4 name -> pull_and_serve (module Ci4_docker) ~name `Service multi_hash
-  | `Docs name -> pull_and_serve (module Docs_docker) ~name `Service multi_hash
-  | `Staging_docs name -> pull_and_serve (module Staging_docs_docker) ~name `Service multi_hash
-  | `Ci name -> pull_and_serve (module Ci_docker) ~name `Service multi_hash
-  | `Opamrepo name -> pull_and_serve (module Opamrepo_docker) ~name `Service multi_hash
-  | `Check name -> pull_and_serve (module Check_docker) ~name `Service multi_hash
-  (* deploy.mirageos.org *)
-  | `Cimirage name -> pull_and_serve (module Cimirage_docker) ~name `Service multi_hash
-  (* ocaml.org *)
-  | `Ocamlorg_deployer name -> pull_and_serve (module Deploycamlorg_docker) ~name `Service multi_hash
-  | `Ocamlorg_images name -> pull_and_serve (module Ocamlorg_images) ~name `Service multi_hash
-  | `OCamlorg_v3b name -> pull_and_serve (module V3b_docker) ~name `Service multi_hash
-  | `OCamlorg_v3c name -> pull_and_serve (module V3c_docker) ~name `Service multi_hash
-
 let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(additional_build_args=Current.return []) src =
   let src = Current.map (fun x -> [x]) src in
   let image_label = Cluster_api.Docker.Image_id.repo hub_id in
@@ -207,5 +163,5 @@ let deploy { sched; dockerfile; options; archs } { hub_id; services } ?(addition
     | [] -> Current.ignore_value multi_hash
     | services ->
       services
-      |> List.map (pull_and_serve multi_hash)
+      |> List.map (pull_and_serve `Service multi_hash)
       |> Current.all

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -336,6 +336,7 @@ module Ocaml_org = struct
   let staging_docs_ci_ocaml_org = "staging.docs.ci.ocaml.org"
   let opam_ci_ocaml_org = "opam.ci.ocaml.org"
   let check_ci_ocaml_org = "check.ci.ocaml.org"
+  let get_dune_build = "get.dune.build"
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -478,7 +479,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/dune-binary-distribution:live"
-              [`Dune_binary_distribution "infra_www"]
+              [{name = "infra_www"; docker_context = Some get_dune_build}]
           ]
       ];
     ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -105,11 +105,11 @@ module Tarides = struct
     "github:tmcgilchrist";
   ]
 
-  (* The docker context for the services, which mostly (but not always)
-     corresponds with the URL whence it is served *)
-  let ocaml_ci_dev = "ocaml.ci.dev"
-  let ci4_ocamllabs_io = "ci4.ocamllabs.io"
-  let ci3_ocamllabs_io= "ci3.ocamllabs.io"
+  (* The docker context for the services *)
+  let default = Cluster.docker_module None
+  let ocaml_ci_dev = Cluster.docker_module (Some "ocaml.ci.dev")
+  let ci4_ocamllabs_io = Cluster.docker_module (Some "ci4.ocamllabs.io")
+  let ci3_ocamllabs_io = Cluster.docker_module (Some "ci3.ocamllabs.io")
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -127,7 +127,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-ci3"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ci3"
-              [{name = "deployer_deployer"; docker_context = None}];
+              [{name = "deployer_deployer"; docker_context = default; uri = Some "deploy.ci.dev"}];
           ]
       ];
       ocurrent, "ocaml-ci", [
@@ -137,7 +137,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocaml-ci-service:live"
-              [{name = "ocaml-ci_ci"; docker_context = Some ocaml_ci_dev}];
+              [{name = "ocaml-ci_ci"; docker_context = ocaml_ci_dev; uri = Some "ocaml.ci.dev:8100"}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -146,7 +146,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocaml-ci-gitlab-service:live"
-              [{name = "ocaml-ci_gitlab"; docker_context = Some ocaml_ci_dev}];
+              [{name = "ocaml-ci_gitlab"; docker_context = ocaml_ci_dev; uri = Some "ocaml.ci.dev:8200"}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -155,11 +155,11 @@ module Tarides = struct
             make_deployment
               ~branch:"live-www"
               ~target:"ocurrent/ocaml-ci-web:live"
-              [{name = "ocaml-ci_web"; docker_context = Some ocaml_ci_dev}];
+              [{name = "ocaml-ci_web"; docker_context = ocaml_ci_dev; uri = Some "ocaml.ci.dev"}];
             make_deployment
               ~branch:"staging-www"
               ~target:"ocurrent/ocaml-ci-web:staging"
-              [{name = "test-www"; docker_context = Some ocaml_ci_dev}];
+              [{name = "test-www"; docker_context = ocaml_ci_dev; uri = None}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
@@ -212,7 +212,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/multicore-ci:live"
-              [{name = "infra_multicore-ci"; docker_context = Some ci4_ocamllabs_io}];
+              [{name = "infra_multicore-ci"; docker_context = ci4_ocamllabs_io; uri = Some "ocaml-multicore.ci.dev:8100"}];
           ];
         make_docker
           "Dockerfile.web"
@@ -220,7 +220,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-web"
               ~target:"ocurrent/multicore-ci-web:live"
-              [{name = "infra_multicore-ci-web"; docker_context = Some ci4_ocamllabs_io}];
+              [{name = "infra_multicore-ci-web"; docker_context = ci4_ocamllabs_io; uri = Some "ocaml-multicore.ci.dev"}];
           ];
       ];
       ocurrent, "ocurrent.org", [
@@ -230,7 +230,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocurrent.org:live-engine"
-              [{name = "ocurrent_org_watcher"; docker_context = Some ci3_ocamllabs_io}];
+              [{name = "ocurrent_org_watcher"; docker_context = ci3_ocamllabs_io; uri = Some "watcher.ci.dev"}];
           ];
       ];
       ocaml_bench, "sandmark-nightly", [
@@ -240,7 +240,7 @@ module Tarides = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/sandmark-nightly:live"
-              [{name = "sandmark_sandmark"; docker_context = Some ci3_ocamllabs_io}];
+              [{name = "sandmark_sandmark"; docker_context = ci3_ocamllabs_io; uri = Some "sandmark.tarides.com"}];
           ]
           ~options:include_git;
       ];
@@ -271,7 +271,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/multicoretests-ci:live"
-              [{name = "infra_multicoretests-ci"; docker_context = Some ci4_ocamllabs_io }];
+              [{name = "infra_multicoretests-ci"; docker_context = ci4_ocamllabs_io; uri = Some "ocaml-multicoretests.ci.dev:8100" }];
           ];
       ];
       ocurrent, "ocurrent-observer", [
@@ -333,15 +333,16 @@ module Ocaml_org = struct
     "github:tmcgilchrist";
   ]
 
-  (* The docker context for the services, which mostly (but not always)
-     corresponds with the URL whence it is served *)
-  let v3b_ocaml_org = "v3b.ocaml.org"
-  let v3c_ocaml_org = "v3c.ocaml.org"
-  let docs_ci_ocaml_org = "docs.ci.ocaml.org"
-  let staging_docs_ci_ocaml_org = "staging.docs.ci.ocaml.org"
-  let opam_ci_ocaml_org = "opam.ci.ocaml.org"
-  let check_ci_ocaml_org = "check.ci.ocaml.org"
-  let get_dune_build = "get.dune.build"
+  (* The docker context for the services *)
+  let default = Cluster.docker_module None
+  let v3b_ocaml_org = Cluster.docker_module (Some "v3b.ocaml.org")
+  let v3c_ocaml_org = Cluster.docker_module (Some "v3c.ocaml.org")
+  let ci3_ocamllabs_io = Cluster.docker_module (Some "ci3.ocamllabs.io")
+  let docs_ci_ocaml_org = Cluster.docker_module (Some "docs.ci.ocaml.org")
+  let staging_docs_ci_ocaml_org = Cluster.docker_module (Some "staging.docs.ci.ocaml.org")
+  let opam_ci_ocaml_org = Cluster.docker_module (Some "opam.ci.ocaml.org")
+  let check_ci_ocaml_org = Cluster.docker_module (Some "check.ci.ocaml.org")
+  let get_dune_build = Cluster.docker_module (Some "get.dune.build")
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -360,7 +361,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live-ocaml-org"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
-              [{name = "infra_deployer"; docker_context = None}];
+              [{name = "infra_deployer"; docker_context = default; uri = Some "deploy.ci.ocaml.org"}];
           ];
       ];
       ocaml, "ocaml.org", [
@@ -371,7 +372,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/v3.ocaml.org-server:live"
-              [{name = "infra_www"; docker_context = Some v3b_ocaml_org}]
+              [{name = "infra_www"; docker_context = v3b_ocaml_org; uri = Some "ocaml.org"}]
           ]
           ~options:include_git;
         (* Staging branch for ocaml.org website. *)
@@ -381,7 +382,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/v3.ocaml.org-server:staging"
-              [{name = "infra_www"; docker_context = Some v3c_ocaml_org}]
+              [{name = "infra_www"; docker_context = v3c_ocaml_org; uri = Some "staging.ocaml.org"}]
           ]
           ~options:include_git
       ];
@@ -393,7 +394,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/base-images:live"
-              [{name = "base-images_builder"; docker_context = Some v3c_ocaml_org}];
+              [{name = "base-images_builder"; docker_context = ci3_ocamllabs_io; uri = Some "images.ci.ocaml.org"}];
           ];
       ];
       ocurrent, "ocaml-docs-ci", [
@@ -403,7 +404,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci:live"
-              [{name = "infra_docs-ci"; docker_context = Some docs_ci_ocaml_org}];
+              [{name = "infra_docs-ci"; docker_context = docs_ci_ocaml_org; uri = Some "docs.ci.ocaml.org"}];
           ];
         make_docker
           "docker/init/Dockerfile"
@@ -411,7 +412,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci-init:live"
-              [{name = "infra_init"; docker_context = Some docs_ci_ocaml_org }];
+              [{name = "infra_init"; docker_context = docs_ci_ocaml_org; uri = None }];
           ];
         make_docker
           "docker/storage/Dockerfile"
@@ -419,7 +420,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci-storage-server:live"
-              [{name = "infra_storage-server"; docker_context = Some docs_ci_ocaml_org }];
+              [{name = "infra_storage-server"; docker_context = docs_ci_ocaml_org; uri = None }];
           ];
         make_docker
           "Dockerfile"
@@ -427,7 +428,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci:staging"
-              [{name = "infra_docs-ci"; docker_context = Some staging_docs_ci_ocaml_org}];
+              [{name = "infra_docs-ci"; docker_context = staging_docs_ci_ocaml_org; uri = Some "staging.docs.ci.ocamllabs.io"}];
           ];
         make_docker
           "docker/init/Dockerfile"
@@ -435,7 +436,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-init:staging"
-              [{name = "infra_init"; docker_context = Some staging_docs_ci_ocaml_org}];
+              [{name = "infra_init"; docker_context = staging_docs_ci_ocaml_org; uri = None}];
           ];
         make_docker
           "docker/storage/Dockerfile"
@@ -443,7 +444,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-storage-server:staging"
-              [{name = "infra_storage-server"; docker_context = Some staging_docs_ci_ocaml_org}];
+              [{name = "infra_storage-server"; docker_context = staging_docs_ci_ocaml_org; uri = None}];
           ];
       ];
       ocurrent, "opam-health-check", [
@@ -453,8 +454,8 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/opam-health-check:live"
-              [ {name = "infra_opam-health-check"; docker_context = Some check_ci_ocaml_org}
-              ; {name = "infra_opam-health-check-freebsd"; docker_context = Some check_ci_ocaml_org}];
+              [ {name = "infra_opam-health-check"; docker_context = check_ci_ocaml_org; uri = Some "check.ci.ocaml.org"}
+              ; {name = "infra_opam-health-check-freebsd"; docker_context = check_ci_ocaml_org; uri = Some "freebsd.check.ci.dev"}];
           ];
       ];
       ocurrent, "opam-repo-ci", [
@@ -464,7 +465,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/opam-repo-ci:live"
-              [{name = "opam-repo-ci_opam-repo-ci"; docker_context = Some opam_ci_ocaml_org }];
+              [{name = "opam-repo-ci_opam-repo-ci"; docker_context = opam_ci_ocaml_org; uri = Some "opam-repo.ci.ocaml.org" }];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -473,7 +474,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live-web"
               ~target:"ocurrent/opam-repo-ci-web:live"
-              [{name = "opam-repo-ci_opam-repo-ci-web"; docker_context = Some opam_ci_ocaml_org }];
+              [{name = "opam-repo-ci_opam-repo-ci-web"; docker_context = opam_ci_ocaml_org; uri = Some "opam.ci.ocaml.org" }];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
@@ -484,7 +485,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/dune-binary-distribution:live"
-              [{name = "infra_www"; docker_context = Some get_dune_build}]
+              [{name = "infra_www"; docker_context = get_dune_build; uri = Some "get.dune.build"}]
           ]
       ];
     ]
@@ -528,7 +529,7 @@ module Ocaml_org = struct
     pipelines, additional_build_args
 
   let watch_ocaml_org = "watch.ocaml.org"
-  module Watch_docker = Current_docker.Make(struct let docker_context = Some watch_ocaml_org end)
+  module Watch_docker = (val Cluster.docker_module (Some watch_ocaml_org))
 
   let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
     (* [web_ui collapse_value] is a URL back to the deployment service, for links
@@ -601,9 +602,8 @@ module Mirage = struct
       ];
     ]
 
-  (* The docker context for the services, which mostly (but not always)
-     corresponds with the URL whence it is served *)
-  let ci_mirage_org = "ci.mirageos.org"
+  (* The docker context for the services *)
+  let ci_mirage_org = Cluster.docker_module (Some "ci.mirageos.org")
 
   let services ?app () : service list =
     (* GitHub organisations to monitor. *)
@@ -616,7 +616,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/mirage-ci:live"
-              [{name = "infra_mirage-ci"; docker_context = Some ci_mirage_org }]
+              [{name = "infra_mirage-ci"; docker_context = ci_mirage_org; uri = Some "ci.mirageos.org" }]
           ]
           ~options:(include_git |> build_kit)
       ];
@@ -627,7 +627,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live-mirage"
               ~target:"ocurrent/deploy.mirageos.org:live"
-              [{name = "infra_deployer"; docker_context = Some ci_mirage_org }]
+              [{name = "infra_deployer"; docker_context = ci_mirage_org; uri = Some "deploy.mirageos.org" }]
           ];
       ];
       ocurrent, "caddy-rfc2136", [
@@ -637,7 +637,7 @@ module Mirage = struct
             make_deployment
               ~branch:"master"
               ~target:"ocurrent/caddy-rfc2136:live"
-              [{name = "infra_caddy"; docker_context = Some ci_mirage_org }]
+              [{name = "infra_caddy"; docker_context = ci_mirage_org; uri = None }]
           ];
       ];
     ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -102,7 +102,8 @@ module Tarides = struct
     "github:tmcgilchrist";
   ]
 
-  (* URLs whence the services is served, which is also used as the docker context *)
+  (* The docker context for the services, which mostly (but not always)
+     corresponds with the URL whence it is served *)
   let ocaml_ci_dev = "ocaml.ci.dev"
   let ci4_ocamllabs_io = "ci4.ocamllabs.io"
   let ci3_ocamllabs_io= "ci3.ocamllabs.io"
@@ -329,7 +330,8 @@ module Ocaml_org = struct
     "github:tmcgilchrist";
   ]
 
-  (* URLs whence the services is served, which is also used as the docker context *)
+  (* The docker context for the services, which mostly (but not always)
+     corresponds with the URL whence it is served *)
   let v3b_ocaml_org = "v3b.ocaml.org"
   let v3c_ocaml_org = "v3c.ocaml.org"
   let docs_ci_ocaml_org = "docs.ci.ocaml.org"
@@ -595,7 +597,8 @@ module Mirage = struct
       ];
     ]
 
-  (* URLs whence the services is served, which is also used as the docker context *)
+  (* The docker context for the services, which mostly (but not always)
+     corresponds with the URL whence it is served *)
   let ci_mirage_io = "ci.mirage.io"
 
   let services ?app () : service list =

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -47,6 +47,8 @@ type deployer =
 module type Deployer = sig
   (** The interface for a pipelines that deploys a set of services *)
 
+  val base_url : Uri.t
+
   val services : ?app:Current_github.App.t -> unit -> service list
 end
 

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -527,7 +527,8 @@ module Ocaml_org = struct
     in
     pipelines, additional_build_args
 
-  module Watch_docker = Current_docker.Make(struct let docker_context = Some "watch.ocaml.org" end)
+  let watch_ocaml_org = "watch.ocaml.org"
+  module Watch_docker = Current_docker.Make(struct let docker_context = Some watch_ocaml_org end)
 
   let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
     (* [web_ui collapse_value] is a URL back to the deployment service, for links
@@ -551,7 +552,7 @@ module Ocaml_org = struct
     in
     let tarsnap =
       let monthly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
-      Current_ssh.run ~schedule:monthly "watch.ocaml.org" ~key:"tarsnap" (Current.return ["./tarsnap-backup.sh"])
+      Current_ssh.run ~schedule:monthly watch_ocaml_org ~key:"tarsnap" (Current.return ["./tarsnap-backup.sh"])
     in
     let peertube =
       let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) () in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -603,7 +603,7 @@ module Mirage = struct
 
   (* The docker context for the services, which mostly (but not always)
      corresponds with the URL whence it is served *)
-  let ci_mirage_io = "ci.mirage.io"
+  let ci_mirage_org = "ci.mirageos.org"
 
   let services ?app () : service list =
     (* GitHub organisations to monitor. *)
@@ -616,7 +616,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/mirage-ci:live"
-              [{name = "infra_mirage-ci"; docker_context = Some ci_mirage_io }]
+              [{name = "infra_mirage-ci"; docker_context = Some ci_mirage_org }]
           ]
           ~options:(include_git |> build_kit)
       ];
@@ -627,7 +627,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live-mirage"
               ~target:"ocurrent/deploy.mirageos.org:live"
-              [{name = "infra_deployer"; docker_context = Some ci_mirage_io }]
+              [{name = "infra_deployer"; docker_context = Some ci_mirage_org }]
           ];
       ];
       ocurrent, "caddy-rfc2136", [
@@ -637,7 +637,7 @@ module Mirage = struct
             make_deployment
               ~branch:"master"
               ~target:"ocurrent/caddy-rfc2136:live"
-              [{name = "infra_caddy"; docker_context = Some ci_mirage_io }]
+              [{name = "infra_caddy"; docker_context = Some ci_mirage_org }]
           ];
       ];
     ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -438,6 +438,17 @@ module Ocaml_org = struct
               [{name = "infra_storage-server"; docker_context = Some staging_docs_ci_ocaml_org}];
           ];
       ];
+      ocurrent, "opam-health-check", [
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              ~branch:"live"
+              ~target:"ocurrent/opam-health-check:live"
+              [ {name = "infra_opam-health-check"; docker_context = Some check_ci_ocaml_org}
+              ; {name = "infra_opam-health-check-freebsd"; docker_context = Some check_ci_ocaml_org}];
+          ];
+      ];
       ocurrent, "opam-repo-ci", [
         make_docker
           "Dockerfile"
@@ -457,17 +468,6 @@ module Ocaml_org = struct
               [{name = "opam-repo-ci_opam-repo-ci-web"; docker_context = Some opam_ci_ocaml_org }];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
-      ];
-      ocurrent, "opam-health-check", [
-        make_docker
-          "Dockerfile"
-          [
-            make_deployment
-              ~branch:"live"
-              ~target:"ocurrent/opam-health-check:live"
-              [ {name = "infra_opam-health-check"; docker_context = Some check_ci_ocaml_org}
-              ; {name = "infra_opam-health-check-freebsd"; docker_context = Some check_ci_ocaml_org}];
-          ];
       ];
       ocaml_dune, "binary-distribution", [
         make_docker

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -348,6 +348,7 @@ module Ocaml_org = struct
   let opam_ci_ocaml_org = docker_context "opam.ci.ocaml.org"
   let check_ci_ocaml_org = docker_context "check.ci.ocaml.org"
   let get_dune_build = docker_context "get.dune.build"
+  let ci3_ocamllabs_io = docker_context "ci3.ocamllabs.io"
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -399,7 +400,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/base-images:live"
-              [{name = "base-images_builder"; docker_context = v3c_ocaml_org; uri = Some "images.ci.ocaml.org"}];
+              [{name = "base-images_builder"; docker_context = ci3_ocamllabs_io; uri = Some "images.ci.ocaml.org"}];
           ];
       ];
       ocurrent, "ocaml-docs-ci", [

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -333,7 +333,7 @@ module Ocaml_org = struct
   let v3b_ocaml_org = "v3b.ocaml.org"
   let v3c_ocaml_org = "v3c.ocaml.org"
   let docs_ci_ocaml_org = "docs.ci.ocaml.org"
-  let staging_docs_ci_ocamllabs_io = "staging.docs.ci.ocamllabs.io"
+  let staging_docs_ci_ocaml_org = "staging.docs.ci.ocaml.org"
   let opam_ci_ocaml_org = "opam.ci.ocaml.org"
   let check_ci_ocaml_org = "check.ci.ocaml.org"
 
@@ -421,7 +421,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci:staging"
-              [{name = "infra_docs-ci"; docker_context = Some staging_docs_ci_ocamllabs_io}];
+              [{name = "infra_docs-ci"; docker_context = Some staging_docs_ci_ocaml_org}];
           ];
         make_docker
           "docker/init/Dockerfile"
@@ -429,7 +429,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-init:staging"
-              [{name = "infra_init"; docker_context = Some staging_docs_ci_ocamllabs_io}];
+              [{name = "infra_init"; docker_context = Some staging_docs_ci_ocaml_org}];
           ];
         make_docker
           "docker/storage/Dockerfile"
@@ -437,7 +437,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-storage-server:staging"
-              [{name = "infra_storage-server"; docker_context = Some staging_docs_ci_ocamllabs_io}];
+              [{name = "infra_storage-server"; docker_context = Some staging_docs_ci_ocaml_org}];
           ];
       ];
       ocurrent, "opam-repo-ci", [

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -54,8 +54,11 @@ end
 
 let docker ~sched ~push_auth { dockerfile; targets; archs; options } =
   let timeout =
-    if List.mem `Linux_riscv64 archs then Int64.mul Build.timeout 2L
-    else Build.timeout
+    if List.mem `Linux_riscv64 archs then
+      (* The risc machines are very slow, so we need to increase the timeout *)
+      Int64.mul Build.timeout 2L
+    else
+      Build.timeout
   in
   let sched = Current_ocluster.v ~timeout ?push_auth sched in
   let build_info = { Cluster.sched; dockerfile = `Path dockerfile; options; archs } in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -109,7 +109,7 @@ module Tarides = struct
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
     the service, and where to deploy it. *)
-  let services ?app () =
+  let services ?app () : service list =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 12497518 in
     let ocaml_bench = Build.org ?app ~account:"ocaml-bench" 19839896 in
@@ -339,7 +339,7 @@ module Ocaml_org = struct
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
     the service, and where to deploy it. *)
-  let services ?app () =
+  let services ?app () : service list =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 23342906 in
     let ocaml = Build.org ?app ~account:"ocaml" 23711648 in
@@ -595,7 +595,7 @@ module Mirage = struct
   (* URLs whence the services is served, which is also used as the docker context *)
   let ci_mirage_io = "ci.mirage.io"
 
-  let services ?app () =
+  let services ?app () : service list =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
     [

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -3,11 +3,11 @@ open Current.Syntax
 module Github = Current_github
 
 (* A docker module parameterized by the docker context indicating the machine a service is a run on *)
-let docker_module context : (module Current_docker.S.DOCKER) =
+let docker_context context : (module Current_docker.S.DOCKER) =
   (module Current_docker.Make(struct let docker_context = (Some context) end))
 
 (* The default docker module indicates the machine that the deployer service itself is run on *)
-let default_docker_module : (module Current_docker.S.DOCKER) =
+let default_docker_context : (module Current_docker.S.DOCKER) =
   (module Current_docker.Default)
 
 let or_fail = function
@@ -114,9 +114,9 @@ module Tarides = struct
   ]
 
   (* The docker context for the services *)
-  let ocaml_ci_dev = docker_module "ocaml.ci.dev"
-  let ci4_ocamllabs_io = docker_module "ci4.ocamllabs.io"
-  let ci3_ocamllabs_io = docker_module "ci3.ocamllabs.io"
+  let ocaml_ci_dev = docker_context "ocaml.ci.dev"
+  let ci4_ocamllabs_io = docker_context "ci4.ocamllabs.io"
+  let ci3_ocamllabs_io = docker_context "ci3.ocamllabs.io"
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -134,7 +134,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-ci3"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ci3"
-              [{name = "deployer_deployer"; docker_context = default_docker_module; uri = Some "deploy.ci.dev"}];
+              [{name = "deployer_deployer"; docker_context = default_docker_context; uri = Some "deploy.ci.dev"}];
           ]
       ];
       ocurrent, "ocaml-ci", [
@@ -341,13 +341,13 @@ module Ocaml_org = struct
   ]
 
   (* The docker context for the services *)
-  let v3b_ocaml_org = docker_module "v3b.ocaml.org"
-  let v3c_ocaml_org = docker_module "v3c.ocaml.org"
-  let docs_ci_ocaml_org = docker_module "docs.ci.ocaml.org"
-  let staging_docs_ci_ocaml_org = docker_module "staging.docs.ci.ocaml.org"
-  let opam_ci_ocaml_org = docker_module "opam.ci.ocaml.org"
-  let check_ci_ocaml_org = docker_module "check.ci.ocaml.org"
-  let get_dune_build = docker_module "get.dune.build"
+  let v3b_ocaml_org = docker_context "v3b.ocaml.org"
+  let v3c_ocaml_org = docker_context "v3c.ocaml.org"
+  let docs_ci_ocaml_org = docker_context "docs.ci.ocaml.org"
+  let staging_docs_ci_ocaml_org = docker_context "staging.docs.ci.ocaml.org"
+  let opam_ci_ocaml_org = docker_context "opam.ci.ocaml.org"
+  let check_ci_ocaml_org = docker_context "check.ci.ocaml.org"
+  let get_dune_build = docker_context "get.dune.build"
 
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
@@ -366,7 +366,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live-ocaml-org"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
-              [{name = "infra_deployer"; docker_context = default_docker_module; uri = Some "deploy.ci.ocaml.org"}];
+              [{name = "infra_deployer"; docker_context = default_docker_context; uri = Some "deploy.ci.ocaml.org"}];
           ];
       ];
       ocaml, "ocaml.org", [
@@ -534,7 +534,7 @@ module Ocaml_org = struct
     pipelines, additional_build_args
 
   let watch_ocaml_org = "watch.ocaml.org"
-  module Watch_docker = (val docker_module watch_ocaml_org)
+  module Watch_docker = (val docker_context watch_ocaml_org)
 
   let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
     (* [web_ui collapse_value] is a URL back to the deployment service, for links
@@ -608,7 +608,7 @@ module Mirage = struct
     ]
 
   (* The docker context for the services *)
-  let ci_mirage_org = docker_module "ci.mirageos.org"
+  let ci_mirage_org = docker_context "ci.mirageos.org"
 
   let services ?app () : service list =
     (* GitHub organisations to monitor. *)

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -95,6 +95,10 @@ module Tarides = struct
     "github:tmcgilchrist";
   ]
 
+  let ocaml_ci_dev = "ocaml.ci.dev"
+  let ci4_ocamllabs_io = "ci4.ocamllabs.io"
+  let ci3_ocamllabs_io= "ci3.ocamllabs.io"
+
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
@@ -111,7 +115,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-ci3"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ci3"
-              [`Ci3 "deployer_deployer"];
+              [{name = "deployer_deployer"; docker_context = None}];
           ]
       ];
       ocurrent, "ocaml-ci", [
@@ -121,7 +125,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocaml-ci-service:live"
-              [`Ci "ocaml-ci_ci"];
+              [{name = "ocaml-ci_ci"; docker_context = Some ocaml_ci_dev}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -130,7 +134,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocaml-ci-gitlab-service:live"
-              [`Ci "ocaml-ci_gitlab"];
+              [{name = "ocaml-ci_gitlab"; docker_context = Some ocaml_ci_dev}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -139,11 +143,11 @@ module Tarides = struct
             make_deployment
               ~branch:"live-www"
               ~target:"ocurrent/ocaml-ci-web:live"
-              [`Ci "ocaml-ci_web"];
+              [{name = "ocaml-ci_web"; docker_context = Some ocaml_ci_dev}];
             make_deployment
               ~branch:"staging-www"
               ~target:"ocurrent/ocaml-ci-web:staging"
-              [`Ci "test-www"];
+              [{name = "test-www"; docker_context = Some ocaml_ci_dev}];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
       ];
@@ -196,7 +200,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/multicore-ci:live"
-              [`Ci4 "infra_multicore-ci"];
+              [{name = "infra_multicore-ci"; docker_context = Some ci4_ocamllabs_io}];
           ];
         make_docker
           "Dockerfile.web"
@@ -204,7 +208,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-web"
               ~target:"ocurrent/multicore-ci-web:live"
-              [`Ci4 "infra_multicore-ci-web"];
+              [{name = "infra_multicore-ci-web"; docker_context = Some ci4_ocamllabs_io}];
           ];
       ];
       ocurrent, "ocurrent.org", [
@@ -214,7 +218,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live-engine"
               ~target:"ocurrent/ocurrent.org:live-engine"
-              [`Ci3 "ocurrent_org_watcher"];
+              [{name = "ocurrent_org_watcher"; docker_context = Some ci3_ocamllabs_io}];
           ];
       ];
       ocaml_bench, "sandmark-nightly", [
@@ -224,7 +228,7 @@ module Tarides = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/sandmark-nightly:live"
-              [`Ci3 "sandmark_sandmark"];
+              [{name = "sandmark_sandmark"; docker_context = Some ci3_ocamllabs_io}];
           ]
           ~options:include_git;
       ];
@@ -255,7 +259,7 @@ module Tarides = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/multicoretests-ci:live"
-              [`Ci4 "infra_multicoretests-ci"];
+              [{name = "infra_multicoretests-ci"; docker_context = Some ci4_ocamllabs_io }];
           ];
       ];
       ocurrent, "ocurrent-observer", [
@@ -326,6 +330,13 @@ module Ocaml_org = struct
     "github:tmcgilchrist";
   ]
 
+  let v3b_ocaml_org = "v3b.ocaml.org"
+  let v3c_ocaml_org = "v3c.ocaml.org"
+  let docs_ci_ocaml_org = "docs.ci.ocaml.org"
+  let staging_docs_ci_ocamllabs_io = "staging.docs.ci.ocamllabs.io"
+  let opam_ci_ocaml_org = "opam.ci.ocaml.org"
+  let check_ci_ocaml_org = "check.ci.ocaml.org"
+
   (* This is a list of GitHub repositories to monitor.
     For each one, it lists the builds that are made from that repository.
     For each build, it says which which branch gives the desired live version of
@@ -343,7 +354,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live-ocaml-org"
               ~target:"ocurrent/ci.ocamllabs.io-deployer:live-ocaml-org"
-              [`Ocamlorg_deployer "infra_deployer"];
+              [{name = "infra_deployer"; docker_context = None}];
           ];
       ];
       ocaml, "ocaml.org", [
@@ -354,7 +365,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/v3.ocaml.org-server:live"
-              [`OCamlorg_v3b "infra_www"]
+              [{name = "infra_www"; docker_context = Some v3b_ocaml_org}]
           ]
           ~options:include_git;
         (* Staging branch for ocaml.org website. *)
@@ -364,7 +375,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/v3.ocaml.org-server:staging"
-              [`OCamlorg_v3c "infra_www"]
+              [{name = "infra_www"; docker_context = Some v3c_ocaml_org}]
           ]
           ~options:include_git
       ];
@@ -376,7 +387,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/base-images:live"
-              [`Ocamlorg_images "base-images_builder"];
+              [{name = "base-images_builder"; docker_context = Some v3c_ocaml_org}];
           ];
       ];
       ocurrent, "ocaml-docs-ci", [
@@ -386,7 +397,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci:live"
-              [`Docs "infra_docs-ci"];
+              [{name = "infra_docs-ci"; docker_context = Some docs_ci_ocaml_org}];
           ];
         make_docker
           "docker/init/Dockerfile"
@@ -394,7 +405,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci-init:live"
-              [`Docs "infra_init"];
+              [{name = "infra_init"; docker_context = Some docs_ci_ocaml_org }];
           ];
         make_docker
           "docker/storage/Dockerfile"
@@ -402,7 +413,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/docs-ci-storage-server:live"
-              [`Docs "infra_storage-server"];
+              [{name = "infra_storage-server"; docker_context = Some docs_ci_ocaml_org }];
           ];
         make_docker
           "Dockerfile"
@@ -410,7 +421,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci:staging"
-              [`Staging_docs "infra_docs-ci"];
+              [{name = "infra_docs-ci"; docker_context = Some staging_docs_ci_ocamllabs_io}];
           ];
         make_docker
           "docker/init/Dockerfile"
@@ -418,7 +429,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-init:staging"
-              [`Staging_docs "infra_init"];
+              [{name = "infra_init"; docker_context = Some staging_docs_ci_ocamllabs_io}];
           ];
         make_docker
           "docker/storage/Dockerfile"
@@ -426,17 +437,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"staging"
               ~target:"ocurrent/docs-ci-storage-server:staging"
-              [`Staging_docs "infra_storage-server"];
-          ];
-      ];
-      ocurrent, "opam-health-check", [
-        make_docker
-          "Dockerfile"
-          [
-            make_deployment
-              ~branch:"live"
-              ~target:"ocurrent/opam-health-check:live"
-              [`Check "infra_opam-health-check"; `Check "infra_opam-health-check-freebsd"];
+              [{name = "infra_storage-server"; docker_context = Some staging_docs_ci_ocamllabs_io}];
           ];
       ];
       ocurrent, "opam-repo-ci", [
@@ -446,7 +447,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/opam-repo-ci:live"
-              [`Opamrepo "opam-repo-ci_opam-repo-ci"];
+              [{name = "opam-repo-ci_opam-repo-ci"; docker_context = Some opam_ci_ocaml_org }];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
         make_docker
@@ -455,9 +456,20 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live-web"
               ~target:"ocurrent/opam-repo-ci-web:live"
-              [`Opamrepo "opam-repo-ci_opam-repo-ci-web"];
+              [{name = "opam-repo-ci_opam-repo-ci-web"; docker_context = Some opam_ci_ocaml_org }];
           ]
           ~archs:[`Linux_x86_64; `Linux_arm64];
+      ];
+      ocurrent, "opam-health-check", [
+        make_docker
+          "Dockerfile"
+          [
+            make_deployment
+              ~branch:"live"
+              ~target:"ocurrent/opam-health-check:live"
+              [ {name = "infra_opam-health-check"; docker_context = Some check_ci_ocaml_org}
+              ; {name = "infra_opam-health-check-freebsd"; docker_context = Some check_ci_ocaml_org}];
+          ];
       ];
       ocaml_dune, "binary-distribution", [
         make_docker
@@ -509,47 +521,42 @@ module Ocaml_org = struct
     in
     pipelines, additional_build_args
 
-  let extras () =
+  module Watch_docker = Current_docker.Make(struct let docker_context = Some "watch.ocaml.org" end)
+
+  let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
+    (* [web_ui collapse_value] is a URL back to the deployment service, for links
+      in status messages. *)
+    let web_ui repo = Uri.with_query' base_url ["repo", repo] in
+    let docker_registry_pipelines =
+      let pipelines, args = opam_repository ?app () in
+      pipelines
+      |> filter_list filter
+      |> List.map (fun (org, name, builds) ->
+          Build_registry.repo ?channel ~additional_build_args:args ~web_ui ~org ~name builds)
+    in
+    let services_pipelines =
+      let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
+      services ?app ()
+      |> List.map (fun (org, name, deployments) ->
+        let deployments = List.map (docker ~sched) deployments in
+        (org, name, deployments))
+      |> filter_list filter
+      |> List.map (fun (org, name, builds) ->
+          Cluster_build.repo ?channel ~web_ui ~org ~name builds)
+    in
     let tarsnap =
       let monthly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
       Current_ssh.run ~schedule:monthly "watch.ocaml.org" ~key:"tarsnap" (Current.return ["./tarsnap-backup.sh"])
     in
     let peertube =
       let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) () in
-      let image = Cluster.Watch_docker.pull ~schedule:weekly "chocobozzz/peertube:production-bookworm" in
-      Cluster.Watch_docker.service ~name:"infra_peertube" ~image ()
-    in
-    [tarsnap; peertube]
-
-  let v ?app ?notify:channel ?filter ~sched ~staging_auth () =
-    (* [web_ui collapse_value] is a URL back to the deployment service, for links
-      in status messages. *)
-    let web_ui repo = Uri.with_query' base_url ["repo", repo] in
-    let build (org, name, builds) =
-      Cluster_build.repo ?channel ~web_ui ~org ~name builds
-    in
-    let build_for_registry ?additional_build_args (org, name, builds) =
-      Build_registry.repo ?channel ?additional_build_args ~web_ui ~org ~name builds
-    in
-    let sched = Current_ocluster.v ~timeout:Build.timeout ?push_auth:staging_auth sched in
-    let docker = docker ~sched in
-    let pipelines =
-      services ?app ()
-      |> List.map (fun (org, name, deployments) ->
-        let deployments = List.map docker deployments in
-        (org, name, deployments))
-      |> filter_list filter
-      |> List.map build
-    in
-    let opam_repository_pipelines, additional_build_args =
-      let pipelines, args = opam_repository ?app () in
-      let filtered_pipelines = filter_list filter @@ pipelines in
-      filtered_pipelines, args
+      let image = Watch_docker.pull ~schedule:weekly "chocobozzz/peertube:production-bookworm" in
+      Watch_docker.service ~name:"infra_peertube" ~image ()
     in
     Current.all (
-      (List.map (build_for_registry ~additional_build_args) opam_repository_pipelines)
-      @ pipelines
-      @ extras ())
+      docker_registry_pipelines
+      @ services_pipelines
+      @ [tarsnap; peertube])
 
   let deployer = {pipeline = v; admins}
 end
@@ -588,6 +595,8 @@ module Mirage = struct
       ];
     ]
 
+  let ci_mirage_io = "ci.mirage.io"
+
   let services ?app () =
     (* GitHub organisations to monitor. *)
     let ocurrent = Build.org ?app ~account:"ocurrent" 6853813 in
@@ -599,7 +608,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/mirage-ci:live"
-              [`Cimirage "infra_mirage-ci"]
+              [{name = "infra_mirage-ci"; docker_context = Some ci_mirage_io }]
           ]
           ~options:(include_git |> build_kit)
       ];
@@ -610,7 +619,7 @@ module Mirage = struct
             make_deployment
               ~branch:"live-mirage"
               ~target:"ocurrent/deploy.mirageos.org:live"
-              [`Cimirage "infra_deployer"]
+              [{name = "infra_deployer"; docker_context = Some ci_mirage_io }]
           ];
       ];
       ocurrent, "caddy-rfc2136", [
@@ -620,7 +629,7 @@ module Mirage = struct
             make_deployment
               ~branch:"master"
               ~target:"ocurrent/caddy-rfc2136:live"
-              [`Cimirage "infra_caddy"]
+              [{name = "infra_caddy"; docker_context = Some ci_mirage_io }]
           ];
       ];
     ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -394,7 +394,7 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"live"
               ~target:"ocurrent/base-images:live"
-              [{name = "base-images_builder"; docker_context = ci3_ocamllabs_io; uri = Some "images.ci.ocaml.org"}];
+              [{name = "base-images_builder"; docker_context = v3c_ocaml_org; uri = Some "images.ci.ocaml.org"}];
           ];
       ];
       ocurrent, "ocaml-docs-ci", [

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -33,6 +33,9 @@ type deployer =
 module type Deployer = sig
   (** A definition of a {!type:deployer}. *)
 
+  val base_url : Uri.t
+  (* The URL from which the deployer is served *)
+
   val services : ?app:Current_github.App.t -> unit -> service list
   (** The list of services deployed *)
 end


### PR DESCRIPTION
The current code declares a type like

```ocaml
type service =
  [ `Ci of string
  ; ...
  ; `Ocamlorg_v3c of string 
  ]
```

Values of this type are used to mark a field in the deployed services 
in `pipeline.ml`. Values of this type are not used anywhere in the 
project except for `cluster.ml`. In that location, they are used to map
to different applications of `pull_and_serve`. Once we remove the unused
AWS entry, every application of `pull_and_serve` is uniform *except* 
that different modules are packed into arguments. The only difference
between these modules is a string value provided when applying the
`Current_docker.Make` to contruct instances of `Current_docker.S.DOCKER`. And
the string value provided there exposes information that we should only know if
you are within the context of a particular deployer.

This PR tries to simplify the situation via the following change: instead of
pre-applying `Current_docker.Make` to special strings, and then using a map from
the `service` type to select the `Current_docker.S.DOCKER` we need, we move the
special string value to the service configuration in `pipeline.ml`, and use
it directly to construct the needed `Current_docker.S.DOCKER`. This
simplification results in the following benefits:

- We remove the `service` type entirely.
- We remove 14 lines of boilerplate functor applications.
- We co-locate the docker context strings with the deployer configurations in
  `pipeline.ml`, further abstracting the "flavours" from the general deployer
  logic, and providing this useful string at the point where we would actually
  want to read it.
- Since we now have this data alongside the services, we are also able to use it
  when generating the `services.md`, so we gain the ability to use this to link
  to the web UI (for most services, the value use for the docker context
  coincides with the service's URL).

A few other incidental cleanups are made along the way. Review by commit may be
useful, tho the diff is not as big as it looks: more than half the new lines are
just from the updated `services.md`, which has a bit more data now and improved
organization.