### PR TITLE
mirage.io moves to mirageos.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Application. These relations are summarized in the following table:
 |-------------|------------------|-------------------------------|-----------------------------------------------|
 | `Tarides`   | `live-ci3`       | <https://deploy.ci.dev>       | <https://github.com/apps/deploy-ci-dev>       |
 | `Ocaml_org` | `live-ocaml-org` | <https://deploy.ci.ocaml.org> | <https://github.com/apps/deploy-ci-ocaml-org> |
-| `Mirage`    | `live-mirage`    | <https://deploy.mirage.io>    | <https://github.com/apps/deploy-mirage-io>    |
+| `Mirage`    | `live-mirage`    | <https://deploy.mirageos.org> | <https://github.com/apps/deploy-mirage-io>    |
 
 The deployer's respective GitHub application is responsible for sending the
 deployer notifications about updates to the repositories being monitored. If the
@@ -144,7 +144,7 @@ To update a deployment that is managed by ocurrent-deployer (which could be ocur
       ```
 
 [OCurrent]: https://github.com/ocurrent/ocurrent
-[MirageOS]: https://mirage.io/
+[MirageOS]: https://mirageos.org/
 [Albatross]: https://github.com/hannesm/albatross
 [pipeline.ml]: ./src/pipeline.ml
 [doc/services.md]: ./doc/services.md

--- a/create-config.sh
+++ b/create-config.sh
@@ -3,7 +3,7 @@
 # Create Docker Context
 docker context create "ci3.ocamllabs.io" --description "Ci3 - Tarides" --docker "host=ssh://root@ci3.ocamllabs.io"
 docker context create "ci4.ocamllabs.io" --description "Ci4 - Tarides" --docker "host=ssh://root@ci4.ocamllabs.io"
-docker context create "ci.mirage.io" --description "Ci - Mirage" --docker "host=ssh://root@ci.mirage.io"
+docker context create "ci.mirageos.org" --description "Ci - Mirage" --docker "host=ssh://root@ci.mirageos.org"
 docker context create "ci.ocamllabs.io" --description "Toxis - Tarides" --docker "host=ssh://root@ci.ocamllabs.io"
 docker context create "deploy.ci.ocaml.org" --description "OCaml - deploy.ci.ocaml.org" --docker "host=ssh://root@deploy.ci.ocaml.org"
 docker context create "dev1.ocamllabs.io" --description "OCaml - opam-repo-ci" --docker "host=ssh://root@dev1.ocamllabs.io"
@@ -31,7 +31,7 @@ mkdir ~/.ssh
 for host in \
   ci3.ocamllabs.io \
   ci4.ocamllabs.io \
-  ci.mirage.io \
+  ci.mirageos.org \
   ci.ocamllabs.io \
   deploy.ci.ocaml.org \
   dev1.ocamllabs.io \

--- a/doc/services.md
+++ b/doc/services.md
@@ -87,7 +87,7 @@ For a given service, the specified Dockerfile is pulled from the specified branc
 
 ### [ocurrent/ocurrent-deployer](https://github.com/ocurrent/ocurrent-deployer)
 - `Dockerfile` on arches: x86_64
-  - branch [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage) built at [`ocurrent/deploy.mirage.io:live`](https://hub.docker.com/r/ocurrent/deploy.mirage.io)
+  - branch [`live-mirage`](https://github.com/ocurrent/ocurrent-deployer/tree/live-mirage) built at [`ocurrent/deploy.mirageos.org:live`](https://hub.docker.com/r/ocurrent/deploy.mirageos.org)
 
 ### [ocurrent/caddy-rfc2136](https://github.com/ocurrent/caddy-rfc2136)
 - `Dockerfile` on arches: x86_64

--- a/src/cluster.ml
+++ b/src/cluster.ml
@@ -36,7 +36,7 @@ module Opamrepo_docker = Current_docker.Make(struct let docker_context = Some "o
 module Check_docker = Current_docker.Make(struct let docker_context = Some "check.ci.ocaml.org" end)
 module Watch_docker = Current_docker.Make(struct let docker_context = Some "watch.ocaml.org" end)
 module Ocamlorg_docker = Current_docker.Make(struct let docker_context = Some "ocaml-www1" end)
-module Cimirage_docker = Current_docker.Make(struct let docker_context = Some "ci.mirage.io" end)
+module Cimirage_docker = Current_docker.Make(struct let docker_context = Some "ci.mirageos.org" end)
 module Ocamlorg_images = Current_docker.Make(struct let docker_context = Some "ci3.ocamllabs.io" end)
 module Docker_aws = Current_docker.Make(struct let docker_context = Some "awsecs" end)
 module V3b_docker = Current_docker.Make(struct let docker_context = Some "v3b.ocaml.org" end)
@@ -61,7 +61,7 @@ type service = [
   | `Docs of string
   | `Staging_docs of string
 
-  (* Services on deploy.mirage.io *)
+  (* Services on deploy.mirageos.org *)
   | `Cimirage of string
 
   (* Services on deploy.ci.ocaml.org. *)
@@ -177,7 +177,7 @@ let pull_and_serve multi_hash = function
   | `Ci name -> pull_and_serve (module Ci_docker) ~name `Service multi_hash
   | `Opamrepo name -> pull_and_serve (module Opamrepo_docker) ~name `Service multi_hash
   | `Check name -> pull_and_serve (module Check_docker) ~name `Service multi_hash
-  (* deploy.mirage.io *)
+  (* deploy.mirageos.org *)
   | `Cimirage name -> pull_and_serve (module Cimirage_docker) ~name `Service multi_hash
   (* ocaml.org *)
   | `Ocamlorg_deployer name -> pull_and_serve (module Deploycamlorg_docker) ~name `Service multi_hash

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -555,7 +555,7 @@ module Ocaml_org = struct
 end
 
 module Mirage = struct
-  let base_url = Uri.of_string "https://deploy.mirage.io/"
+  let base_url = Uri.of_string "https://deploy.mirageos.org/"
 
   let admins = [
     "github:avsm";
@@ -609,7 +609,7 @@ module Mirage = struct
           [
             make_deployment
               ~branch:"live-mirage"
-              ~target:"ocurrent/deploy.mirage.io:live"
+              ~target:"ocurrent/deploy.mirageos.org:live"
               [`Cimirage "infra_deployer"]
           ];
       ];


### PR DESCRIPTION
Please check and test carefully, since I don't have a clue on how such a rename should be done, and whether any other steps are necessary. Thanks a lot.

Reference: https://github.com/mirage/mirage-www/pull/845

Note: the DNS entries for ci.mirageos.org and deploy.mirageos.org are already established.