### PR TITLE
feat: add staging branch forocaml-dune/binary-distribution

### DIFF
--- a/doc/services.md
+++ b/doc/services.md
@@ -190,11 +190,14 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - services:
     - `infra_www` @ <https://preview.dune.build>
 
+
+### [ocaml-dune/binary-distribution](https://github.com/ocaml-dune/binary-distribution)
+
 - `Dockerfile` on arches: x86_64
   - branch: [`staging`](https://github.com/ocaml-dune/binary-distribution/tree/staging)
   - registered image: [`ocurrent/dune-binary-distribution:staging`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
   - services:
-    - `infra_www` @ <https://preview.dune.build>
+    - `infra_staging` @ <https://staging-preview.dune.build>
 
 
 ## Mirage Docker services

--- a/doc/services.md
+++ b/doc/services.md
@@ -188,7 +188,13 @@ For a given service, the specified Dockerfile is pulled from the specified branc
   - branch: [`main`](https://github.com/ocaml-dune/binary-distribution/tree/main)
   - registered image: [`ocurrent/dune-binary-distribution:live`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
   - services:
-    - `infra_www` @ <https://get.dune.build>
+    - `infra_www` @ <https://preview.dune.build>
+
+- `Dockerfile` on arches: x86_64
+  - branch: [`staging`](https://github.com/ocaml-dune/binary-distribution/tree/staging)
+  - registered image: [`ocurrent/dune-binary-distribution:staging`](https://hub.docker.com/r/ocurrent/dune-binary-distribution)
+  - services:
+    - `infra_www` @ <https://preview.dune.build>
 
 
 ## Mirage Docker services

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -503,7 +503,7 @@ module Ocaml_org = struct
               make_deployment
                 ~branch:"staging"
                 ~target:"ocurrent/dune-binary-distribution:staging"
-                [{name = "infra_www"; docker_context = get_dune_build; uri = Some "staging-preview.dune.build"}]
+                [{name = "infra_staging"; docker_context = get_dune_build; uri = Some "staging-preview.dune.build"}]
             ]
         ];
     ]

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -493,9 +493,19 @@ module Ocaml_org = struct
             make_deployment
               ~branch:"main"
               ~target:"ocurrent/dune-binary-distribution:live"
-              [{name = "infra_www"; docker_context = get_dune_build; uri = Some "get.dune.build"}]
+              [{name = "infra_www"; docker_context = get_dune_build; uri = Some "preview.dune.build"}]
           ]
       ];
+      ocaml_dune, "binary-distribution", [
+          make_docker
+            "Dockerfile"
+            [
+              make_deployment
+                ~branch:"staging"
+                ~target:"ocurrent/dune-binary-distribution:staging"
+                [{name = "infra_www"; docker_context = get_dune_build; uri = Some "staging-preview.dune.build"}]
+            ]
+        ];
     ]
 
   let opam_repository ?app () =


### PR DESCRIPTION
This PR changes the service `uri` to match reality and add a new service on `ocaml-dune/binary-distribution:staging`. This service is in charge of building the preview.dune.build website in a context of a test environment.