### PR TITLE
Repoint mirage unikernel deploys to dopey

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 7103cbf7d886d93402af1c852db818b4a3fba7ec && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard b7773e2175e3ba6fbca47e183f7d342b18f24b37 && opam update
 RUN opam option --global solver=builtin-0install
 COPY --chown=opam --link deployer.opam /src/
 # WORKDIR must be after COPY to avoid perms problems

--- a/create-config.sh
+++ b/create-config.sh
@@ -45,7 +45,7 @@ for host in \
   ocaml.ci.dev \
   check.ci.ocaml.org \
   128.232.124.216 \
-  147.75.84.37 ; do
+  dopey.caelum.ci.dev ; do
   ssh-keyscan -H -t ecdsa-sha2-nistp256 $host >> ~/.ssh/known_hosts
 done
 chmod 700 ~/.ssh

--- a/src/packet_unikernel.ml
+++ b/src/packet_unikernel.ml
@@ -42,7 +42,7 @@ let name { service } = service
 
 (* Deployment *)
 
-let mirage_host_ssh = "root@147.75.84.37"
+let mirage_host_ssh = "root@dopey.caelum.ci.dev"
 
 let deploy build_info { service } ?additional_build_args:_ src =
   let repo_id = build_and_push build_info src in


### PR DESCRIPTION
infra-2 (`147.75.84.37`, Equinix bare-metal) is being decommissioned. The mirage unikernels (`www`, `next`) now run under albatross on `dopey.caelum.ci.dev`.

This points the deploy SSH host and the `create-config.sh` ssh-keyscan at dopey. The build/extract path is unchanged (OCluster build → push to `ocurrentbuilder/staging` → `crane export` → rsync → `mirage-redeploy`).